### PR TITLE
Add reviewer org to event submission

### DIFF
--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -273,7 +273,7 @@
   import ImageUploadService from '@/services/ImageUploadService'
 
   export default {
-    props: ['event_id', 'user_role', 'user_action'],
+    props: ['event_id', 'user_role', 'user_action', 'reviewOrg'],
     // user_role --> admin, venue, regular
     // user_action --> upload, edit
     data: function () {
@@ -361,7 +361,8 @@
 
         const event = {
           ...this.calendar_event,
-          organizers: this.calendar_event.organizers ? this.calendar_event.organizers.split(',') : []
+          organizers: this.calendar_event.organizers ? this.calendar_event.organizers.split(',') : [],
+          reviewed_by_org: this.reviewOrg ? this.reviewOrg : null
         }
 
         ImageUploadService.forEvent(

--- a/web-portal/pages/submit-event.vue
+++ b/web-portal/pages/submit-event.vue
@@ -16,7 +16,7 @@
         </div>
       </div>
       <client-only>
-        <submission-form :user_action="'upload'" :user_role="'regular'"></submission-form>
+        <submission-form :user_action="'upload'" :user_role="'regular'" :review-org="partner ? partner.id : null" />
       </client-only>
     </v-app>
   </div>

--- a/web-portal/services/PartnerService.js
+++ b/web-portal/services/PartnerService.js
@@ -1,7 +1,8 @@
 const PARTNERS = {
   wrfl: {
     name: 'WRFL',
-    logo: '/images/partners/wrfl.svg'
+    logo: '/images/partners/wrfl.svg',
+    id: 'wrfl'
   }
 }
 


### PR DESCRIPTION
When the submission form is loaded with a partner specified, include that partner in the request body to set the `reviewed_by_org` field on the event.