### PR TITLE
issue-58: Show organizer contact to admins

### DIFF
--- a/e2e-tests/integration/eventSubmissionTest.js
+++ b/e2e-tests/integration/eventSubmissionTest.js
@@ -77,6 +77,8 @@ context('Event Submission', () => {
     cy.contains('.calendar-events-table tr:last-child td', EVENT_NAME)
     cy.get('.calendar-events-table tr:last-child a').contains('Edit').click()
     cy.location('pathname').should('include', 'admin-event-edit')
+    cy.get('.submitter-email input').should('have.value', 'test@te.st')
+
     cy.get('button.btn-verify').click()
     cy.get('.calendar-events-table')
     cy.contains('.calendar-events-table tr:last-child td', EVENT_NAME).should('not.exist')

--- a/web-portal/pages/admin-event-edit/_id/index.vue
+++ b/web-portal/pages/admin-event-edit/_id/index.vue
@@ -26,9 +26,11 @@
         venues: []
       }
     },
-    fetch: function ({ store, params }) {
+    fetch: function ({ store, params, app }) {
+      const idToken = app.$auth.$storage.getState('_token.auth0')
+
       return Promise.all([
-        store.dispatch('admin/LoadCurrentEvent', params.id),
+        store.dispatch('admin/LoadCurrentEvent', { id: params.id, idToken }),
         store.dispatch('LoadAllVenueData')
       ])
     },

--- a/web-portal/store/admin.js
+++ b/web-portal/store/admin.js
@@ -21,8 +21,11 @@ export const getters = {
 }
 
 export const actions = {
-  LoadCurrentEvent: (context, id) => {
-    return ApiService.get('/events/' + id)
+  LoadCurrentEvent: (context, payload) => {
+    const id = payload.id
+    const idToken = payload.idToken
+
+    return ApiService.get('/events/' + id, idToken)
       .then((response) => {
         if (response.data.status === 'success') { context.commit('POPULATE_CURRENT_EVENT', response.data.event, { root: true }) }
       })


### PR DESCRIPTION
the edit page now passes the token when fetching the event to edit which
allows the organizer contact e-mail to be shown if the user is an admin