### PR TITLE
Update Jumbotron message and add link to remote page

### DIFF
--- a/web-portal/components/Jumbotron.vue
+++ b/web-portal/components/Jumbotron.vue
@@ -5,7 +5,13 @@
         X
       </div>
       <p>
-        {{ jumbotron.message }}
+        Due to the outbreak of Coronavirus disease (COVID-19) we are hitting a pause on
+        our live event promotion activities. We're on the lookout for interesting things
+        happening online, though; check out our new
+        <nuxt-link to="/remote">remote events page</nuxt-link>.
+      </p>
+      <p>
+        Keep calm, avoid crowded spaces, wash your hands and stay healthy y'all!
       </p>
     </div>
   </div>
@@ -17,8 +23,7 @@
     data: function () {
       return {
         jumbotron: {
-          open: true,
-          message: 'Due to the outbreak of Coronavirus disease (COVID-19) we are hitting a pause on our event promotion activities. Keep calm, avoid crowded spaces, wash your hands and stay healthy y\'all!'
+          open: true
         }
       }
     },
@@ -63,6 +68,9 @@
 
     font-family: "EB Garamond";
     font-size: 1.25em;
+
+    background-color: white;
+    color: black;
   }
 
   #close-jumbotron {

--- a/web-portal/components/Navigation.vue
+++ b/web-portal/components/Navigation.vue
@@ -66,6 +66,7 @@
       return {
         nav_items: [
           { title: 'Home', route: '/' },
+          { title: 'Remote Events', route: '/remote' },
           { title: 'Our Mission', route: '/our-mission' },
           { title: 'Submit Event', route: '/submit-event' },
           { title: 'Login', route: '/login', isUnAuthOnly: true },

--- a/web-portal/layouts/default.vue
+++ b/web-portal/layouts/default.vue
@@ -1,8 +1,5 @@
 <template>
   <div>
-    <!-- So sometimes we have pandemics in this world -->
-    <ii-jumbotron />
-
     <!-- Notifications -->
     <ii-notifications />
 
@@ -26,15 +23,13 @@
   import Notifications from '../components/Notifications.vue'
   import Subscribe from '../components/Subscribe.vue'
   import Modal from '../components/Modal.vue'
-  import Jumbotron from '../components/Jumbotron.vue'
 
   export default {
     components: {
       'ii-toolbar': Toolbar,
       'ii-notifications': Notifications,
       'ii-modal': Modal,
-      'ii-subscribe': Subscribe,
-      'ii-jumbotron': Jumbotron
+      'ii-subscribe': Subscribe
     },
     data() {
       return {

--- a/web-portal/pages/index.vue
+++ b/web-portal/pages/index.vue
@@ -1,9 +1,15 @@
 <template>
-  <ii-list-viewer :calendar_events="events" />
+  <div>
+    <!-- So sometimes we have pandemics in this world -->
+    <ii-jumbotron />
+
+    <ii-list-viewer :calendar_events="events" />
+  </div>
 </template>
 
 <script>
   import ListViewer from '../components/ListViewer.vue'
+  import Jumbotron from '../components/Jumbotron.vue'
 
   export default {
     data: function () {
@@ -23,7 +29,8 @@
       ])
     },
     components: {
-      'ii-list-viewer': ListViewer
+      'ii-list-viewer': ListViewer,
+      'ii-jumbotron': Jumbotron
     }
   }
 </script>


### PR DESCRIPTION
Jumbotron and Navigation menu now have links to the new remote events page

![Screen Shot 2020-03-31 at 6 59 57 PM](https://user-images.githubusercontent.com/4068894/78082777-d8976f80-7381-11ea-84b0-aa75b9d7592c.png)
