### PR TITLE
Hide datepicker when creating online resource events

### DIFF
--- a/web-portal/components/AdminEventsList.vue
+++ b/web-portal/components/AdminEventsList.vue
@@ -12,7 +12,10 @@
       <tr v-for="calendar_event in calendar_events" :key="calendar_event.id">
         <td><img v-if="calendar_event.reviewed_by_org" :src="calendar_event.reviewed_by_org | ownerLogo" width="30" /></td>
         <td>{{ calendar_event.title }}</td>
-        <td><div v-for="(date_time, index) in calendar_event.date_times" :key="index">{{ date_time | dateFormat }}</div></td>
+        <td>
+          <div v-for="(date_time, index) in calendar_event.date_times" :key="index">{{ date_time | dateFormat }}</div>
+          <template v-if="calendar_event.tags && calendar_event.tags.includes('online-resource')">Online Resource</template>
+        </td>
         <td><v-btn nuxt :to="{ name: 'admin-event-edit-id', params: { id: calendar_event.id } }">Edit</v-btn></td>
       </tr>
     </tbody>

--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -25,14 +25,18 @@
           <v-checkbox v-model="eventIsRemote" label="Live Remote Event" />
         </v-flex>
         <v-flex xs12 sm4 md4>
-          <v-checkbox v-model="eventIsOnline" label="Online Resource / Project" />
+          <v-checkbox v-model="eventIsOnline" label="Online Resource / Project" @change="onOnlineChange" />
         </v-flex>
         <v-flex xs8 offset-xs3>
           <em>Live remote events occur at a particular time. Online Resources are available at any time.</em>
         </v-flex>
       </v-layout>
 
-      <date-time-picker v-model="calendar_event.date_times" />
+      <v-expansion-panel expand v-model="showDateTimePicker">
+        <v-expansion-panel-content>
+          <date-time-picker v-model="calendar_event.date_times" />
+        </v-expansion-panel-content>
+      </v-expansion-panel>
 
       <!-- Event Image -->
       <v-layout row wrap>
@@ -520,6 +524,11 @@
 
       // console.log(this.promoHTML)
       },
+      onOnlineChange: function () {
+        if (this.eventIsOnline) {
+          this.calendar_event.date_times = []
+        }
+      },
       onFileChange: function (type) {
         // files.length will be a 0 for no image, 1 for image
         if (type === 'event') {
@@ -543,11 +552,9 @@
       },
       hasValidDateTimes: function () {
         if (this.calendar_event.hasOwnProperty('date_times')) {
-          if (this.calendar_event.date_times.length > 0) {
-            return true
-          } else {
-            return false
-          }
+          // online resources don't have fixed times
+          if (this.calendar_event.tags.includes('online-resource')) return this.calendar_event.date_times.length === 0
+          else return this.calendar_event.date_times.length > 0
         } else {
           return false
         }
@@ -584,6 +591,10 @@
 
       eventIsPostponed: boolToTag('postponed'),
       eventIsCancelled: boolToTag('cancelled'),
+
+      showDateTimePicker: function () {
+        return [!this.eventIsOnline]
+      },
 
       eventRequiredFields: function () {
         return this.calendar_event.title !== '' &&

--- a/web-portal/services/ApiService.js
+++ b/web-portal/services/ApiService.js
@@ -25,6 +25,10 @@ export class ApiService {
     return axios.delete(API_URL + path, idToken ? { headers: { 'x-access-token': userToken } } : null)
   }
 
+  static all(calls) {
+    return axios.all(calls)
+  }
+
   static makeApiCall(verb, path, postBody, apiKey, userToken) {
     let url = API_URL + '/' + path
     let args = []


### PR DESCRIPTION
- Collapse datepicker component on SubmissionForm when "Online Resource / Project" is checked
- Modify admin page to build unverified events list from result of traditional unverified events endpoint + unverified resources