### PR TITLE
Single-event support for the widget

### DIFF
--- a/widget/README.md
+++ b/widget/README.md
@@ -5,9 +5,10 @@ Widget for embedding events from the Infinite Industries platform on a website.
 ## Installation
 
 - Add an `div` or other element with class `infinite-widget` to your main template where you want to place the widget.
-- Add these attributes to the container element:
+- Add these (optional) attributes to the container element:
   - `data-widget-title`
   - `data-cards-per-page` (controls the number of events that will appear at a time)
+  - `data-event-id` (if set to a valid event ID, will cause the widget to display a single card for that event only)
 - Add this script, replacing `1.0` with the version you want to use:
 
   ```html

--- a/widget/src/apiService.js
+++ b/widget/src/apiService.js
@@ -1,15 +1,26 @@
+import ConfigService from './configService.js'
 
 export default class APIService {
 
-    static get(path, callback){
-        // console.log("Started API call")
+    static getEvents(callback) {
+        APIService.get(`${ConfigService.getApiUrl()}/events/current/verified?embed=venue`, function(err, response) {
+            callback(err, response ? response.events : null)
+        })
+    }
 
+    static getEvent(eventId, callback) {
+        APIService.get(`${ConfigService.getApiUrl()}/events/${eventId}`, function(err, response) {
+            callback(err, response ? response.event : null)
+        })
+    }
+
+    static get(path, callback){
         fetch(path)
         .then(function(response) {
             return response.json()
         })
         .then(function(data) {
-            callback(null, data.events)
+            callback(null, data)
         })
         .catch(function(err) {
             callback(err)

--- a/widget/src/configService.js
+++ b/widget/src/configService.js
@@ -56,6 +56,11 @@ export default class ConfigService {
         return attr ? attr : DEFAULT_PAGE_SIZE
     }
 
+    static getEventId() {
+        const attr = widget_container.getAttribute('data-event-id')
+        return attr ? attr : null
+    }
+
     static getSiteUrl() {
         return URLS[mode].SITE
     }

--- a/widget/src/errorMessage.js
+++ b/widget/src/errorMessage.js
@@ -1,0 +1,9 @@
+
+export default function ErrorMessage(error) {
+    console.error(error)
+    return `
+    <div class="infinite-error">
+        <h2>Unable to reach the server :(</h2>
+        <p>For the nerds among us, the error output is in the console log.</p>
+    </div>`
+}

--- a/widget/src/eventViewer.js
+++ b/widget/src/eventViewer.js
@@ -1,0 +1,19 @@
+import ConfigService from './configService.js'
+// Import Card template and renderer
+import Card from './card.js'
+
+export default function EventViewer(context, event) {
+
+    const content = document.createElement('div')
+    content.setAttribute("id", "infinite-widget-content")
+    context.appendChild(content)
+
+    content.innerHTML = Card(event)
+
+    // inject the image -- this is a bit hacky, need to think through a more elegant solution
+    // TODO: can we not do this within the card? And if not, can we refactor this into a component?
+    const last_child = content.lastChild
+    const image_container = last_child.querySelector(".infinite-image-container")
+
+    image_container.innerHTML = '<a href="' + ConfigService.getSiteUrl() + '/events/' + event.id +'" target="_new"><div class="image-surface" style="width:100%;height:150px; background:url(' + event.image + ') center center / cover no-repeat;cursor:pointer;"></div></a>'
+}

--- a/widget/src/index.js
+++ b/widget/src/index.js
@@ -1,19 +1,20 @@
 // Infinite Industries Widget
 
-const PATH = 'events/current/verified?embed=venue'
-
 // Import API helper
 import APIService from './apiService.js'
 import ConfigService from './configService.js'
 import RenderCardsViewer from './cardsViewer.js'
+import RenderEventViewer from './eventViewer.js'
 import RenderHeader from './header.js'
 import Loader from './loader.js'
 import Pagination from './pagination.js'
+import ErrorMessage from './errorMessage.js'
 
 document.addEventListener("DOMContentLoaded", () => {
     // console.log("begin injecting widget content")
     const infinite_widget_container = ConfigService.getContainer()
     const cards_per_page = ConfigService.getPageSize()
+    const event_id = ConfigService.getEventId()
     let which_page = 0
 
     if(infinite_widget_container !== null){
@@ -26,33 +27,44 @@ document.addEventListener("DOMContentLoaded", () => {
         loader.style.alignContent = 'center'
         infinite_widget_container.appendChild(loader)
 
-
         console.log("Loading widget content...")
 
-        APIService.get(`${ConfigService.getApiUrl()}/${PATH}`, (err, events) => {
-            if(err){
-                infinite_widget_container.innerHTML = "<h2>Unable to reach the server :(</h2> <p>For the nerds among us, the error output is in the console log.</p>"
-                console.log(err)
-            }
-            else {
-                loader.remove()
-
-                const cards_viewer_container = document.createElement('div')
-                cards_viewer_container.setAttribute("id", "infinite-card-viewer-container")
-                infinite_widget_container.appendChild(cards_viewer_container)
-
-                let cards_viewer = RenderCardsViewer(cards_viewer_container, events, cards_per_page, which_page)
-
-                if((events.length - cards_per_page)>=0){
-                    // window.$e0 = infinite_widget_container
-                    // console.log(infinite_widget_container.innerWidth)
-                    Pagination(events, function (new_page_number) {
-                        cards_viewer.remove()
-                        cards_viewer = RenderCardsViewer(cards_viewer_container, events, cards_per_page, new_page_number)
-                    })
+        if (event_id) {
+            // special mode: render single card
+            APIService.getEvent(event_id, (err, event) => {
+                if (err) {
+                    infinite_widget_container.innerHTML = ErrorMessage(err)
+                } else {
+                    loader.remove()
+                    RenderEventViewer(infinite_widget_container, event)
                 }
-            }
-        })
+            })
+        } else {
+            // render list
+            APIService.getEvents((err, events) => {
+                if(err){
+                    infinite_widget_container.innerHTML = ErrorMessage(err)
+                }
+                else {
+                    loader.remove()
+
+                    const cards_viewer_container = document.createElement('div')
+                    cards_viewer_container.setAttribute("id", "infinite-card-viewer-container")
+                    infinite_widget_container.appendChild(cards_viewer_container)
+
+                    let cards_viewer = RenderCardsViewer(cards_viewer_container, events, cards_per_page, which_page)
+
+                    if((events.length - cards_per_page)>=0){
+                        // window.$e0 = infinite_widget_container
+                        // console.log(infinite_widget_container.innerWidth)
+                        Pagination(events, function (new_page_number) {
+                            cards_viewer.remove()
+                            cards_viewer = RenderCardsViewer(cards_viewer_container, events, cards_per_page, new_page_number)
+                        })
+                    }
+                }
+            })
+        }
     }
     else {
         console.log("Please make sure that element with id \"infinite-widget\" is present in the body of your document.")

--- a/widget/src/style.css
+++ b/widget/src/style.css
@@ -303,3 +303,7 @@ select {
       transform: rotate(360deg);
     }
   }
+
+.infinite-error {
+    color: white;
+}


### PR DESCRIPTION
- Adds support for data-attr "data-event-id", which, when present, will cause the widget to render only a single card for that event instead of the list
- Refactors error display into a component for reusability
- Refactors APIService to have individual methods for the two API calls it makes

resolves #155 