### PR TITLE
Fix issue with server dropping event description

### DIFF
--- a/api-server-nest/src/events/dto/create-event-request.ts
+++ b/api-server-nest/src/events/dto/create-event-request.ts
@@ -66,6 +66,7 @@ export class CreateEventRequest {
     brief_description: string;
 
     @ApiProperty({example: '<h2>The Gallery Is Open</h2><p>Some details</p>'})
+    @IsOptional()
     description: string;
 
     @ApiProperty({example: 'https://www.wegotrats.com'})


### PR DESCRIPTION
Not sure why the IsOptional decorator is necessary, but without it the description is silently dropped.