### PR TITLE
Wrap Jumbotron in client-only tag

### DIFF
--- a/web-portal/pages/index.vue
+++ b/web-portal/pages/index.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <!-- So sometimes we have pandemics in this world -->
-    <ii-jumbotron />
+    <client-only>
+      <ii-jumbotron />
+    </client-only>
 
     <ii-list-viewer :calendar_events="events" />
 


### PR DESCRIPTION
This might address the intermittent error message we see locally and right after deploys.