### PR TITLE
Throttle the Jumbotron message

### DIFF
--- a/web-portal/components/Jumbotron.vue
+++ b/web-portal/components/Jumbotron.vue
@@ -19,6 +19,22 @@
 <script>
   import Close from './vectors/Close.vue'
 
+  const THROTTLE_INTERVAL = 5 * 60 * 1000 // 5 minutes
+
+  const LAST_VIEWED = 'ii-jumbotron-viewed-at'
+
+  function getLastViewed() {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage.getItem(LAST_VIEWED)
+    } else return null
+  }
+
+  function setLastViewed() {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.setItem(LAST_VIEWED, Date.now())
+    }
+  }
+
   export default {
     name: 'Jumbotron',
     data: function () {
@@ -34,7 +50,11 @@
     fetch: function () {
       return this.$store.dispatch('LoadAnnouncements').then(() => {
         if (this.currentAnnouncement && this.currentAnnouncement.message.trim().length !== 0) {
-          this.open = true
+          const lastViewed = getLastViewed()
+          if (!lastViewed || (Date.now() - parseFloat(lastViewed)) > THROTTLE_INTERVAL) {
+            setLastViewed()
+            this.open = true
+          }
         }
       })
     },


### PR DESCRIPTION
The Jumbotron now writes a timestamp for its last show time to localstorage, and checks that timestamp against the current time on subsequent loads. If it has been shown in the previous 5 minutes, it is suppressed.

closes #227