### PR TITLE
Add support for local image uploads on web portal

### DIFF
--- a/web-portal/.gitignore
+++ b/web-portal/.gitignore
@@ -100,3 +100,4 @@ analytics.sqlite
 clientConfig.js
 cypress.env.json
 keys
+static/uploads

--- a/web-portal/internal-api/upload-managers/LocalUploader.js
+++ b/web-portal/internal-api/upload-managers/LocalUploader.js
@@ -1,0 +1,21 @@
+const fs = require('fs')
+const { join, resolve } = require('path')
+
+const LOCAL_UPLOAD_ROOT = resolve(__dirname, '../../static')
+
+module.exports = class LocalUploader {
+  constructor(urlBase) {
+    this.urlBase = urlBase
+  }
+
+  upload(path, data) {
+    return new Promise((resolve, reject) => {
+      // wx flag mitigates the possibility of clobbering an existing file
+      // (will error out on write)
+      fs.writeFile(join(LOCAL_UPLOAD_ROOT, path), data, { flag: 'wx' }, (err) => {
+        if (err) reject(err)
+        else resolve(this.urlBase + '/' + path)
+      })
+    })
+  }
+}

--- a/web-portal/internal-api/upload-managers/S3Uploader.js
+++ b/web-portal/internal-api/upload-managers/S3Uploader.js
@@ -1,0 +1,28 @@
+const aws = require('aws-sdk')
+
+module.exports = class S3Uploader {
+  constructor(urlBase, region, accessKeyId, secretAccessKey, bucket) {
+    this.urlBase = urlBase + bucket
+    this.region = region
+    this.bucket = bucket
+
+    this.s3 = new aws.S3({
+      region,
+      accessKeyId,
+      secretAccessKey
+    })
+  }
+
+  upload(path, data) {
+    return new Promise((resolve, reject) => {
+      this.s3.putObject({
+        Body: data,
+        Bucket: this.bucket,
+        Key: path
+      }, (err) => {
+        if (err) reject(err)
+        else resolve(this.urlBase + '/' + path)
+      })
+    })
+  }
+}


### PR DESCRIPTION
If the proper AWS credentials and configuration aren't available, the web portal can now fall back on saving image uploads to the static directory.

This shouldn't be used in production, but is convenient for a dev machine or test environment.