### PR TITLE
migration: add column timezone to table datetime_venue

### DIFF
--- a/api-server/migrations/20211114154401-add-timezone-to-datetime_venue.js
+++ b/api-server/migrations/20211114154401-add-timezone-to-datetime_venue.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.addColumn(
+      'datetime_venue',
+      'timezone',
+      {
+        type: Sequelize.STRING,
+        defaultValue: 'America/New_York',
+        allowNull: false
+      }
+    )
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn(
+      'datetime_venue',
+      'timezone'
+    )
+  }
+};


### PR DESCRIPTION
track timezone names (corresponding to values in table `pg_timezone_names`) with new column `timezone` in table `datetime_venue`.

this migration sets the default value for this column to `America/New_York`. if needed, this can be changed with a future migration when we build functionality to enter timezone information from the front end.

here's a sample query using the information from this new column. you can run this inside the database (after running this migration) to see one way we might use the information from this new column in the future:

```
SELECT
  event_id,
  start_time AT TIME ZONE timezone AS start_ny,
  start_time AS start_utc,
  end_time AT TIME ZONE timezone AS end_ny,
  end_time AS end_utc,
  timezone
FROM datetime_venue
ORDER BY random()
LIMIT 20;
```

you'll notice that times in the spring/summer (Eastern Daylight Time) are four hours offset from UTC, and those in fall/winter (Easter Standard Time) are five hours offset from UTC. this is the advantage of using timezone names rather than codes.