### PR TITLE
Submit event on shift-click of preview button

### DIFF
--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -229,7 +229,7 @@
               :flat="false"
               :outline="!eventRequiredFields"
               depressed
-              @click="PreviewEvent"
+              @click="e => e.shiftKey ? UploadEvent() : PreviewEvent()"
             >Preview Event</v-btn>
           </div>
         </v-flex>


### PR DESCRIPTION
This "power-user" feature will make it easier for core dev team members -- who don't really need a preview -- to submit events.