### PR TITLE
Allow admins to use dates in the past when editing events

### DIFF
--- a/web-portal/components/DateTimePicker.vue
+++ b/web-portal/components/DateTimePicker.vue
@@ -182,6 +182,11 @@
   export default {
     name: 'DateTimePicker',
     props: {
+      mode: {
+        type: String,
+        default: 'upload',
+        validator: value => value === 'upload' || value === 'edit'
+      },
       value: {
         type: Array,
         default: () => []
@@ -214,7 +219,9 @@
     },
     methods: {
       AllowedDates: function (val) {
-        if (moment(val).isSameOrAfter(moment().subtract(1, 'd'))) return val
+        // in edit mode, anything goes
+        // otherwise, disallow days in the past
+        return this.mode === 'edit' || moment(val).isSameOrAfter(moment().subtract(1, 'd'))
       },
 
       /* Converts start and end times stored in data to formatted strings for display in the ui */

--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -34,7 +34,7 @@
 
       <v-expansion-panel expand v-model="showDateTimePicker">
         <v-expansion-panel-content>
-          <date-time-picker v-model="calendar_event.date_times" />
+          <date-time-picker v-model="calendar_event.date_times" :mode="user_action" />
         </v-expansion-panel-content>
       </v-expansion-panel>
 


### PR DESCRIPTION
When editing events through the admin portal, dates in the past can now be selected. New submissions still disallow past dates.

resolves #270