### PR TITLE
Tweak meridiem selectors on submission form

### DIFF
--- a/web-portal/components/DateTimePicker.vue
+++ b/web-portal/components/DateTimePicker.vue
@@ -389,6 +389,13 @@
     min-height: 50px;
   }
 
+  /* this overrides some Vuetify reset styling so that the meridiem selects */
+  /* are easier to identify as interactive form controls */
+  .time-date-entry select {
+    -moz-appearance: auto;
+    -webkit-appearance: auto;
+  }
+
   .label {
     color: rgb(154, 154, 154);
   }


### PR DESCRIPTION
Minor CSS tweak restores the chevron / down arrow to make it more apparent they're form controls.

references #292