### PR TITLE
Fix Email Filter

### DIFF
--- a/api-server/src/authentication/filters/remove-sensitive-data-for-non-admins.ts
+++ b/api-server/src/authentication/filters/remove-sensitive-data-for-non-admins.ts
@@ -2,36 +2,38 @@ import {Request} from "express";
 import isAdminUser from "../is-admin-user";
 import EventDTO from "../../events/dto/eventDTO";
 
-type GenericEvent = EventDTO
-type GenericEventList = EventDTO[]
+type EventOrEventList = EventDTO | EventDTO []
 
-export async function removeSensitiveDataForNonAdmins(
+export async function removeSensitiveDataForNonAdmins <T extends EventOrEventList>(
     request: Request,
-    events: GenericEvent | GenericEventList
-): Promise<GenericEvent | GenericEventList> {
+    events: T
+): Promise<T> {
     const isAdmin = await isAdminUser(request);
 
     if (isAdmin) {
         return events
     }
 
-    if (Array.isArray(events)) {
-        return removeSensitiveDataList(events)
+    if (isGenericEventList(events)) {
+        return removeSensitiveDataList(events) as T
     } else {
-        return removeSensitiveDataForSingleEvent(events)
+        return removeSensitiveDataForSingleEvent(events as EventDTO) as T
     }
 }
 
-function removeSensitiveDataList(currentEvents: GenericEventList): GenericEventList {
+function removeSensitiveDataList(currentEvents: EventDTO []): EventDTO [] {
     if (currentEvents.length === 0) {
         return []
-    } else if (currentEvents[0] instanceof EventDTO) {
-        return (currentEvents as EventDTO[]).map(removeSensitiveDataForSingleEvent);
     } else {
-        return (currentEvents as EventDTO[]).map(removeSensitiveDataForSingleEvent);
+        return (currentEvents).map(removeSensitiveDataForSingleEvent);
     }
 }
 
-function removeSensitiveDataForSingleEvent(infiniteEvent: GenericEvent): GenericEvent {
+function removeSensitiveDataForSingleEvent(infiniteEvent: EventDTO): EventDTO {
     return {...infiniteEvent, organizer_contact: undefined }
+}
+
+
+function isGenericEventList(arg: EventOrEventList): arg is  EventDTO [] {
+    return Array.isArray(arg)
 }

--- a/api-server/src/events/dto/eventModelToEventDTO.ts
+++ b/api-server/src/events/dto/eventModelToEventDTO.ts
@@ -1,6 +1,7 @@
 import {EventModel} from "../models/event.model";
 import EventDTO from "./eventDTO";
 import {StartEndTimePairs} from "../../shared-types/start-end-time-pairs";
+import isNotNullOrUndefined from "../../utils/is-not-null-or-undefined";
 
 export function eventModelToEventDTO(eventModel: EventModel): EventDTO {
     const date_times: StartEndTimePairs [] = eventModel.date_times.map((dt) => {
@@ -37,7 +38,6 @@ export function eventModelToEventDTO(eventModel: EventModel): EventDTO {
         verified: eventModel.verified,
         website_link: eventModel.website_link,
         date_times,
-        venue: eventModel.venues[0],
-
+        venue: isNotNullOrUndefined(eventModel.venues) ? eventModel.venues[0] : null,
     }
 }

--- a/api-server/src/events/dto/events-response.ts
+++ b/api-server/src/events/dto/events-response.ts
@@ -1,10 +1,10 @@
 import {ResponseWrapper} from "../../dto/response-wrapper";
 import isNotNullOrUndefined from "../../utils/is-not-null-or-undefined";
 import cloneAttributes from "../../utils/clone-attributes";
-import {EventModel} from '../models/event.model'
+import EventDTO from "./eventDTO";
 
 export class EventsResponse extends ResponseWrapper {
-    events: EventModel []
+    events: EventDTO []
 
     constructor(copy?: Partial<EventsResponse>) {
         super()

--- a/api-server/src/events/events.controller.ts
+++ b/api-server/src/events/events.controller.ts
@@ -42,7 +42,8 @@ export class EventsController {
     })
     getAllCurrentVerified(
         @Query('embed') embed: string[] | string = [],
-        @Query('tags') tags: string[] | string = []
+        @Query('tags') tags: string[] | string = [],
+        @Req() request: Request
     ): Promise<EventsResponse> {
         if (typeof embed === 'string') {
             embed = [embed, 'DATE_TIME']
@@ -68,6 +69,8 @@ export class EventsController {
         };
 
         return this.eventsService.findAll(findOptions)
+            .then(events => events.map(eventModelToEventDTO))
+            .then(events => removeSensitiveDataForNonAdmins(request, events))
             .then(events => new EventsResponse({ events }));
     }
 
@@ -80,7 +83,8 @@ export class EventsController {
     })
     getAllVerified(
         @Query('embed') embed: string[] | string = [],
-        @Query('tags') tags: string[] | string = []
+        @Query('tags') tags: string[] | string = [],
+        @Req() request: Request
     ): Promise<EventsResponse> {
         const findOptions = {
             ...getOptionsForEventsServiceFromEmbedsQueryParam(embed),
@@ -88,9 +92,12 @@ export class EventsController {
         };
 
         return this.eventsService.findAll(findOptions)
+            .then((events) => events.map(eventModelToEventDTO))
+            .then(event => removeSensitiveDataForNonAdmins(request, event))
             .then(events => new EventsResponse({ events }));
     }
 
+    // TODO - Move to events.authenticated.controller
     @Get('non-verified')
     @UseGuards(AuthGuard)
     @ApiOperation({ summary: 'Get events that have not yet been verified (admin only)' })
@@ -106,6 +113,7 @@ export class EventsController {
         };
 
         return this.eventsService.findAll(findOptions)
+            .then((events) => events.map(eventModelToEventDTO))
             .then(events => new EventsResponse({ events }));
     }
 
@@ -135,6 +143,7 @@ export class EventsController {
             .then((event: EventDTO) => ({ event, status: 'success' }))
     }
 
+    // TODO - Move to events.authenticated.controller
     @Get()
     @UseGuards(AuthGuard)
     @ApiOperation({ summary: 'Get events, both verified and non (admin only)' })
@@ -150,6 +159,7 @@ export class EventsController {
         };
 
         return this.eventsService.findAll(findOptions)
+            .then((events) => events.map(eventModelToEventDTO))
             .then(events => new EventsResponse({ events }));
     }
 

--- a/api-server/test/current-events.e2e-spec.ts
+++ b/api-server/test/current-events.e2e-spec.ts
@@ -237,8 +237,6 @@ describe('CurrentEvents (e2e)', () => {
                 expect(remainingTimes.length).toEqual(2);
                 expect(new Date(remainingTimes[0].start_time)).toEqual(firstDayTime.start_time);
                 expect(new Date(remainingTimes[1].start_time)).toEqual(secondDayTime.start_time);
-                expect(new Date(event.first_day_start_time)).toEqual(firstDayTime.start_time);
-                expect(new Date(event.last_day_end_time)).toEqual(secondDayTime.end_time);
 
                 done();
             });
@@ -264,7 +262,6 @@ describe('CurrentEvents (e2e)', () => {
                 expect(event.verified).toEqual(dbEvent.verified);
                 expect(event.title).toEqual(dbEvent.title);
                 expect(event.slug).toEqual(dbEvent.slug);
-                expect(event.multi_day).toEqual(dbEvent.multi_day);
                 expect(event.image).toEqual(dbEvent.image);
                 expect(event.social_image).toEqual(dbEvent.social_image);
                 expect(event.admission_fee).toEqual(dbEvent.admission_fee);
@@ -286,8 +283,8 @@ describe('CurrentEvents (e2e)', () => {
 
                 // check datetimes
                 expect(event.date_times.length).toEqual(1)
-                expect(new Date(event.date_times[0].start_time)).toEqual(futureTime.start_time)
-                expect(new Date(event.date_times[0].end_time)).toEqual(futureTime.end_time)
+                expect(event.date_times[0].start_time).toEqual(futureTime.start_time.toISOString())
+                expect(event.date_times[0].end_time).toEqual(futureTime.end_time.toISOString())
 
                 done()
             });

--- a/web-portal/components/EventCard.vue
+++ b/web-portal/components/EventCard.vue
@@ -103,22 +103,7 @@
         return !!this.calendar_event.venue_id && (!!this.calendar_event.venue || (!!this.venue && !!this.venue.id))
       },
       venue: function () {
-        // venues should be included on event
-        // if not, the event may have been fetched without the proper flag set,
-        // in which case we may be able to silently recover by consulting a
-        // global list of venues
-        const event = this.calendar_event
-        if (event.venues && event.venues.length > 0) {
-          return event.venues[0]
-        } else if (event.venue_id) {
-          const all_venues = this.$store.getters.GetActiveVenues
-
-          const current_venue = all_venues.find((venue) => {
-            return venue.id === event.venue_id
-          })
-
-          return current_venue === undefined ? {} : current_venue
-        } else return {}
+        return this.calendar_event.venue || {}
       },
       showTime: function () {
         return !_hasTag(this.calendar_event, 'category:online-resource') &&
@@ -158,6 +143,10 @@
     },
     filters: {
       truncate: function (text, stop, clamp) {
+        if (text === undefined || text === null) {
+          return ''
+        }
+
         return text.slice(0, stop) + (stop < text.length ? clamp || '...' : '')
       }
     },

--- a/web-portal/test/EventCard.spec.js
+++ b/web-portal/test/EventCard.spec.js
@@ -18,8 +18,16 @@ const getEvent = () => {
       { start_time: '2020-06-02T22:00:00', end_time: '2020-06-02T23:00:00' }
     ],
     brief_description: 'The event lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed consequat ipsum neque.',
+    venue: getVenue(),
     venue_id: venueId,
     tags: []
+  }
+}
+
+const getVenue = () => {
+  return {
+    id: venueId,
+    name: venueName
   }
 }
 
@@ -30,7 +38,7 @@ describe('Card component', () => {
     event = getEvent()
     store = new Vuex.Store({
       state: {},
-      getters: { GetActiveVenues: () => [{ id: venueId, name: venueName }] }
+      getters: { GetActiveVenues: () => [ getVenue() ] }
     })
     wrapper = shallowMount(Card, {
       localVue,


### PR DESCRIPTION
organizer contact should be filtered out if the user accessing them is
not an admin. This filter needs to be applied to any endpoint that
allows non-authenticated access.

To get this working a bit of tech debt had to be payed down. It was the
expectation that we would return an EventDTO model over the wire rather
than the database model. This gives us space to normalize the format for
the api rather than except whatever format sequelize returns, for
example we currently flatten venues to venue since we only allow one
venue right now and we do some normalization of data/time values.

This transformation was not getting applied everywhere but our our
filter functions expected the transformed type.

This PR:

1. Makes sure all even endpoints expose the proper DTO
2. Applies organizer_contact filter to all endpoints that don't require
   authentication
3. Updates frontend code that wasn't expecting the venue field to
   already be set

Notes:

* If you hit an endpoint that does not require authentication but
you are authenticated as a site admin the filter will not be applied and
you will get back the organizer_contact.
* We don't bother invoking the filter at all on endpoints that require
  authentication as we don't have any non-admin user roles at the
  moment. If you are authenticated you are admin so even if we applied
  the filtering code it would see that your are an admin and doing
  nothing.
