### PR TITLE
Hard-code Google Analytics ID in build

### DIFF
--- a/web-portal/Dockerfile
+++ b/web-portal/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:gallium
 
+ARG GOOGLE_ANALYTICS_ID='UA-73795062-1'
+ENV GOOGLE_ANALYTICS_ID=${GOOGLE_ANALYTICS_ID}
+
 ADD ./ /web-portal
 
 RUN npm install -g npm@8.7.0

--- a/web-portal/docker-build.sh
+++ b/web-portal/docker-build.sh
@@ -9,7 +9,7 @@ container_name="infinite-web-portal"
 
 echo "$script_name: building $container_name for tag $tag"
 
-docker build -t "$container_name:$tag" .
+docker build --build-arg "GOOGLE_ANALYTICS_ID=UA-73795062-1" -t "$container_name:$tag" .
 
 echo "$script_name: finished building $container_name for tag $tag"
 


### PR DESCRIPTION
Looks like the Google Analytics module is baking the value in at build time (and removing itself if it doesn't have a value). Until we can work around that, we'll bake it in at build time.