### PR TITLE
Improve event submission preview on small screens

### DIFF
--- a/web-portal/components/SubmissionPreview.vue
+++ b/web-portal/components/SubmissionPreview.vue
@@ -28,17 +28,23 @@
 
 <style scoped>
   .event-preview {
-    display: flex;
-    flex-direction: row;
     background-color: black;
     border-radius: 10px;
     padding: 10px;
+  }
+
+  @media only screen and (min-width: 640px) {
+    .event-preview {
+      display: flex;
+      flex-direction: row;
+    }
   }
 
   .event-preview > div {
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding: 0 5px;
   }
 
   .event-preview > div:first-child {
@@ -51,11 +57,12 @@
 
   .event-preview > div > div:first-child {
     font-size: 1.25em;
-    margin-bottom: 1em;
+    margin-bottom: 0.75em;
     color: white;
   }
 
   .event-preview .card-container {
     max-height: 450px;
+    padding: 0;
   }
 </style>


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/4068894/213338243-c0358140-4454-4c57-9ced-b1359f5611f4.png)

(not shown: the card preview, which is under the event preview on screens below 640px wide)

resolves #346