### PR TITLE
Prompt user when leaving submit page w/out submitting

### DIFF
--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -415,6 +415,10 @@
       })
     },
     methods: {
+      /** @public */
+      isDirty: function () {
+        return !isEqual(this.calendar_event, this.$store.getters.GetCurrentEvent)
+      },
       UpdateEvent: function () {
         console.log(this.calendar_event)
         this.showEventLoadingSpinner = true


### PR DESCRIPTION
Uses `beforeunload` event, which isn't perfect but might save a few people (probably mostly ourselves) some grief from time to time

Related in spirit to #393