### PR TITLE
Update API test job configuration

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -17,8 +17,9 @@ on:
       - '.github/workflows/api-tests.yml'
 
 jobs:
-  build:
+  api-e2e-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -35,3 +36,11 @@ jobs:
         working-directory: './api-server'
         env:
           PORT: 3003
+      - name: Save server logs
+        uses: actions/upload-artifact@v3
+        if : ${{ failure() }}
+        with:
+          name: server-logs
+          path: |
+            api-server/test/logs
+          retention-days: 14 # this gives us two weeks to troubleshoot

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - 'api-server/**'
       - '.github/workflows/api-tests.yml'
+  workflow_dispatch:  # manual execution through Github UI
 
 jobs:
   api-e2e-tests:


### PR DESCRIPTION
- Set timeout on Github workflow to 10 minutes (resolves #448)
- Preserve server logs from test run on Github as a workflow artifact (resolves #447)