### PR TITLE
Update submission preview UI

### DIFF
--- a/e2e-tests/integration/eventSubmissionTest.js
+++ b/e2e-tests/integration/eventSubmissionTest.js
@@ -68,6 +68,8 @@ context('Event Submission', () => {
     // preview submission
     cy.get('.submit-container button').click()
     cy.get('.event-preview').should('exist')
+    // NOTE: preview is tabbed on smaller screens; this only works because Cypress
+    // still sees the content in the DOM, even though it isn't visible
     cy.get('.event .event-heading h1').contains(TEMP_EVENT_NAME).should('exist')
     cy.get('.infinite-card h3').contains(TEMP_EVENT_NAME).should('exist')
     // check that venue field contains something

--- a/web-portal/components/SubmissionPreview.vue
+++ b/web-portal/components/SubmissionPreview.vue
@@ -1,12 +1,26 @@
 <template>
   <div class="event-preview">
-    <div>
-      <div>Event View</div>
-      <event-view :event="event" />
+    <div class="controls">
+      <!-- buttons control which preview panel is displayed on small screens -->
+      <!-- (TODO: this needs proper accessibility consideration, `role`s + keyboard control) -->
+      <div class="mode-toggle">
+        <button type="button" :class="{ 'active': mode === 'view' }" @click="mode = 'view'">
+          Full Event View
+        </button>
+        <button type="button" :class="{ 'active': mode === 'card' }" @click="mode = 'card'">
+          Card View
+        </button>
+      </div>
     </div>
-    <div>
-      <div>Card View</div>
-      <event-card :calendar_event="event" preview />
+    <div class="event-preview-screens">
+      <div class="event-preview-screen" :class="{'active': mode === 'view'}">
+        <div>Event View</div>
+        <event-view :event="event" />
+      </div>
+      <div class="event-preview-screen" :class="{'active': mode === 'card'}">
+        <div>Card View</div>
+        <event-card :calendar_event="event" preview />
+      </div>
     </div>
   </div>
 </template>
@@ -19,6 +33,12 @@
     props: [
       'event'
     ],
+    data() {
+      return {
+        // card | view
+        mode: 'view'
+      }
+    },
     components: {
       'event-card': EventCard,
       'event-view': EventView
@@ -27,41 +47,110 @@
 </script>
 
 <style scoped>
-  .event-preview {
+  /* on smaller screens, need extra margin to avoid content hidden under
+     fixed controls */
+  @media screen and (max-width: 959px) {
+    .event-preview {
+      margin-bottom: 6rem;
+    }
+  }
+
+  .controls {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 2em;
+  }
+
+  .mode-toggle {
+    display: flex;
+    flex-direction: row;
+    gap: 0;
+  }
+
+  .mode-toggle button {
+    padding: 1rem 0.5rem;
+    border: 2px solid black;
+    background-color: #d8d7d7;
+  }
+
+  .mode-toggle button:first-child {
+    border-top-left-radius: 10px;
+    border-bottom-left-radius: 10px;
+    border-right: none;
+  }
+
+  .mode-toggle button:last-child {
+    border-top-right-radius: 10px;
+    border-bottom-right-radius: 10px;
+    border-left: none;
+  }
+
+  .mode-toggle button.active {
+    background-color: black;
+    color: white;
+  }
+
+  /* for larger-than-tablet screens, show both views side-by-side,
+     and hide unncessary controls */
+  @media only screen and (min-width: 1024px) {
+    .controls {
+      display: none;
+    }
+  }
+
+  .event-preview-screens {
     background-color: black;
     border-radius: 10px;
     padding: 10px;
   }
 
-  @media only screen and (min-width: 640px) {
-    .event-preview {
-      display: flex;
-      flex-direction: row;
-    }
-  }
-
-  .event-preview > div {
+  .event-preview-screens > div {
     display: flex;
     flex-direction: column;
     align-items: center;
     padding: 0 5px;
   }
 
-  .event-preview > div:first-child {
-    flex-basis: 67%;
+  /* only show the "active" preview element */
+  .event-preview-screens > div:not(.active) {
+    display: none;
   }
 
-  .event-preview > div:last-child {
-    flex-basis: 33%
-  }
-
-  .event-preview > div > div:first-child {
+  .event-preview-screens > div > div:first-child {
     font-size: 1.25em;
     margin-bottom: 0.75em;
     color: white;
+
+    /* hide preview labels on smaller screens,
+       when only one is visible at a time */
+    display: none;
   }
 
-  .event-preview .card-container {
+  /* for larger screens, always show both views */
+  @media only screen and (min-width: 1024px) {
+    .event-preview-screens {
+      display: flex;
+      flex-direction: row;
+    }
+
+    .event-preview-screens > div:not(.active) {
+      display: flex;
+    }
+
+    .event-preview-screens > div:first-child {
+      flex-basis: 67%;
+    }
+
+    .event-preview-screens > div:last-child {
+      flex-basis: 33%
+    }
+
+    .event-preview-screens > div > div:first-child {
+      display: block;
+    }
+  }
+
+  .event-preview-screens .card-container {
     max-height: 450px;
     padding: 0;
   }

--- a/web-portal/pages/submit-event.vue
+++ b/web-portal/pages/submit-event.vue
@@ -17,8 +17,8 @@
             <div class="preview-message">
               <p>Please review the information for your event</p>
               <div class="preview-controls">
-                <button class="ii-button" @click="submitEventForReal">SUBMIT FOR REVIEW</button>
-                <button class="ii-button secondary-button" @click="changeTheEvent">BACK TO EDITING</button>
+                <button class="ii-button" @click="submitEventForReal">Submit for Review</button>
+                <button class="ii-button secondary-button" @click="changeTheEvent">Back to Editing</button>
               </div>
             </div>
           </template>
@@ -222,7 +222,27 @@
   }
 
   .preview-controls {
-    margin-left: 100px;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    background-color: black;
+  }
+
+  .preview-controls .ii-button {
+    min-width: 250px;
+    border-radius: 10px;
+  }
+
+  @media only screen and (min-width: 640px) {
+    .preview-controls {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+    }
   }
 
   .centered-header {


### PR DESCRIPTION
- Preview panels are tabbed on smaller screens (still side-by-side on larger screens)
- Submit/back-to-edit buttons fixed to bottom of screen and restyled for mobile

references #443