### PR TITLE
Issue #458: Handle Image Upload Errors Gracefully

### DIFF
--- a/api-server/src/uploads/uploads.controller.ts
+++ b/api-server/src/uploads/uploads.controller.ts
@@ -15,8 +15,8 @@ import { UploadsResponse } from './dto/UploadsResponse';
 import { UploadsService } from './uploads.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Request } from 'express';
-
-const TEN_MEGABYTES = 10000000;
+import EventImageMaxFileSizeValidator from './validators/EventImageMaxFileSizeValidator';
+import EventImageFileTypeValidator from './validators/EventImageFileTypeValidator';
 
 @Controller(`${VERSION_1_URI}/uploads`)
 @ApiTags('uploads')
@@ -45,13 +45,10 @@ export class UploadsController {
 
 function getImageUploadValidators(): ParseFilePipe {
   return new ParseFilePipeBuilder()
-    .addFileTypeValidator({
-      fileType: /image\/.*$/i,
-    })
-    .addMaxSizeValidator({
-      maxSize: TEN_MEGABYTES,
-    })
+    .addValidator(new EventImageFileTypeValidator())
+    .addValidator(new EventImageMaxFileSizeValidator())
     .build({
       errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      fileIsRequired: true,
     });
 }

--- a/api-server/src/uploads/validators/EventImageFileTypeValidator.ts
+++ b/api-server/src/uploads/validators/EventImageFileTypeValidator.ts
@@ -1,0 +1,12 @@
+import { FileTypeValidator } from '@nestjs/common';
+
+const VALIDATION_EXPRESSION = /image\/.*$/i;
+
+export default class EventImageFileTypeValidator extends FileTypeValidator {
+  constructor() {
+    super({ fileType: VALIDATION_EXPRESSION });
+  }
+  override buildErrorMessage(): string {
+    return 'The file must be a valid image type (jpg, png, gif, webp, etc...).';
+  }
+}

--- a/api-server/src/uploads/validators/EventImageMaxFileSizeValidator.ts
+++ b/api-server/src/uploads/validators/EventImageMaxFileSizeValidator.ts
@@ -1,0 +1,16 @@
+import { MaxFileSizeValidator } from '@nestjs/common';
+
+const TEN_MEGABYTES = 10000000;
+
+export default class EventImageMaxFileSizeValidator extends MaxFileSizeValidator {
+  constructor() {
+    super({ maxSize: TEN_MEGABYTES });
+  }
+
+  override buildErrorMessage(): string {
+    const maxSizeInMegabytes = () => this.validationOptions.maxSize / 1000000;
+    const formattedMaxSize = () => maxSizeInMegabytes().toLocaleString();
+
+    return `Event images must be less than ${formattedMaxSize()} megabytes.`;
+  }
+}

--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -507,7 +507,7 @@
           this.showEventLoadingSpinner = false
           this.$emit('submitted')
         }).catch((error) => {
-          console.error(`error uploading image: ${error}`)
+          console.error('error uploading image:', error)
 
           this.showEventLoadingSpinner = false
           this.eventSubmitted = false

--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -332,7 +332,7 @@
       <!-- CONFIRM EVENT DELETION -->
       <v-dialog v-model="dialog" persistent max-width="300">
         <v-card>
-          <v-card-title class="headline">U shure you wanna delete the event?</v-card-title>
+          <v-card-title class="headline">U sure you wanna delete the event?</v-card-title>
           <v-card-actions>
             <v-spacer></v-spacer>
             <v-btn color="green darken-1" flat="flat" @click.native="dialog = false">Cancel</v-btn>
@@ -507,11 +507,12 @@
           this.showEventLoadingSpinner = false
           this.$emit('submitted')
         }).catch((error) => {
-          console.log(error)
+          console.error(`error uploading image: ${error}`)
+
           this.showEventLoadingSpinner = false
           this.eventSubmitted = false
 
-          this.$emit('error')
+          this.$emit('error', { error })
         })
       },
       selectVenue: function (venue) {

--- a/web-portal/pages/submit-event.vue
+++ b/web-portal/pages/submit-event.vue
@@ -55,8 +55,8 @@
               </p>
 
               <p class="infinite-submission-form__report-problem-message">
-                Please ping the management at or go back and try again
-                <a href="mailto:info@infinite.industries">info@infinite.industries</a>.
+                Please ping the management at <a href="mailto:info@infinite.industries">info@infinite.industries</a> or
+                go back and try again.
               </p>
 
               <button

--- a/web-portal/pages/submit-event.vue
+++ b/web-portal/pages/submit-event.vue
@@ -45,10 +45,36 @@
             <h1 class="centered-header">
               Hmmm... something went wrong :(
             </h1>
-            <p style="text-align: center">
-              Please ping the management at
-              <a href="mailto:info@infinite.industries">info@infinite.industries</a>.
-            </p>
+
+            <div class="infinite-submission-form__error-info-section">
+              <p
+                class="infinite-submission-form__error-message"
+                v-if="submissionErrorMessage !== null"
+              >
+                {{submissionErrorMessage}}
+              </p>
+
+              <p class="infinite-submission-form__report-problem-message">
+                Please ping the management at or go back and try again
+                <a href="mailto:info@infinite.industries">info@infinite.industries</a>.
+              </p>
+
+              <button
+                class="ii-button"
+                @click="handleErrorDismissed()"
+              >
+                Back To Form
+              </button>
+
+<!--              <div>
+                <v-btn
+                  color="green"
+                  :flat="false"
+                  depressed
+                  @click="handleErrorDismissed()"
+                >Back To Form</v-btn>
+              </div>-->
+            </div>
           </template>
 
         </div>
@@ -68,7 +94,7 @@
           ref="form"
           @preview="onPreview"
           @submitted="mode = 'success'"
-          @error="mode = 'error'"
+          @error="handleSubmissionError"
         />
         <submission-preview
           v-if="mode == 'preview'"
@@ -96,7 +122,8 @@
       return {
         mode: 'edit',
         previewEvent: null,
-        partner: null
+        partner: null,
+        submissionErrorMessage: null
       }
     },
     asyncData: function ({ query }) {
@@ -166,6 +193,23 @@
           // eslint-disable-next-line no-return-assign
           return event.returnValue = 'You have unsaved changes. Sure?'
         }
+      },
+      handleSubmissionError: function({ error }) {
+        this.mode = 'error'
+
+        const errorResp = error?.response
+
+        if (
+          errorResp !== null &&
+          errorResp !== undefined &&
+          !!errorResp?.data?.message
+        ) {
+          this.submissionErrorMessage = errorResp.data.message
+        }
+      },
+      handleErrorDismissed: function() {
+        this.submissionErrorMessage = null
+        this.mode = 'edit'
       }
     },
     components: {
@@ -264,5 +308,13 @@
     display: block;
     margin: 35px auto 0;
     height: 150px;
+  }
+
+  .infinite-submission-form__error-info-section {
+    text-align: center;
+  }
+
+  .infinite-submission-form__error-message {
+    color: red;
   }
 </style>

--- a/web-portal/pages/submit-event.vue
+++ b/web-portal/pages/submit-event.vue
@@ -65,15 +65,6 @@
               >
                 Back To Form
               </button>
-
-<!--              <div>
-                <v-btn
-                  color="green"
-                  :flat="false"
-                  depressed
-                  @click="handleErrorDismissed()"
-                >Back To Form</v-btn>
-              </div>-->
             </div>
           </template>
 


### PR DESCRIPTION
Now that the backend is doing more validation and some post processing of images there more chance for the user to encounter submission errors that they can recover from.

This pr improves the validation messages returned from the server

Makes sure that the messages when available are displayed to the user on the error screen

And finally gives the user a way to dismiss the error screen and try again without losing any work on the form.

![Screenshot from 2024-01-20 11-50-19](https://github.com/infinite-industries/infinite/assets/1688763/07ea73d0-6ba7-44e3-9e1e-5b4611645347)

![Screenshot from 2024-01-20 11-59-22](https://github.com/infinite-industries/infinite/assets/1688763/2c2b28a8-f886-43ec-9c4e-0252b8ab2591)
