### PR TITLE
Issue #481 and #485 Small Bug Fixes

### DIFF
--- a/api-server/src/app.module.ts
+++ b/api-server/src/app.module.ts
@@ -16,6 +16,7 @@ import {
   DB_PASSWORD,
   DB_PORT,
   DB_USER_NAME,
+  ENV,
   SEQUELIZE_LOGGING,
   SQL_IS_USING_SSL,
 } from './constants';
@@ -56,7 +57,7 @@ const dialectOptions = SQL_IS_USING_SSL
         // TODO: should we factor this out into a secondary file?
         new transports.Console({
           format: format.combine(
-            format.label({ label: `TEST:api-server:${process.pid}` }),
+            format.label({ label: `${ENV}:api-server:${process.pid}` }),
             format.timestamp(),
             format.colorize(),
             format.printf(({ level, message, label, timestamp }) => {

--- a/api-server/src/events/events.controller.ts
+++ b/api-server/src/events/events.controller.ts
@@ -1,6 +1,16 @@
 import moment from 'moment';
 import { Op, literal } from 'sequelize';
-import { Body, Controller, Get, Param, Post, Query, Req } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpException,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
 import { EventsService } from './events.service';
 import { EventModel } from './models/event.model';
 import { Inject, LoggerService } from '@nestjs/common';
@@ -28,6 +38,7 @@ import {
   EVENT_PAGINATION_DEFAULT_PAGE_SIZE,
   PaginationDto,
 } from './dto/pagination-dto';
+import { isNullOrUndefined } from '../utils';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
@@ -168,6 +179,13 @@ export class EventsController {
     return this.eventsService
       .findById(id, findOptions)
       .then((event) => Promise.resolve(event))
+      .then((event) => {
+        if (isNullOrUndefined(event)) {
+          throw new NotFoundException('Could not find event: ' + id);
+        } else {
+          return event;
+        }
+      })
       .then(eventModelToEventDTO)
       .then((event) => removeSensitiveDataForNonAdmins(request, event))
       .then((event: EventDTO) => ({ event, status: 'success' }));

--- a/api-server/test/test-helpers/assert-events.ts
+++ b/api-server/test/test-helpers/assert-events.ts
@@ -3,6 +3,7 @@ import { EventModel } from '../../src/events/models/event.model';
 export function assertEventsEqual(
   actualReturned: any,
   expectedEvent: EventModel,
+  compareAuthenticatedUser = true,
 ) {
   expect(actualReturned.id).toEqual(expectedEvent.id);
   expect(actualReturned.verified).toEqual(expectedEvent.verified);
@@ -11,9 +12,16 @@ export function assertEventsEqual(
   expect(actualReturned.image).toEqual(expectedEvent.image);
   expect(actualReturned.social_image).toEqual(expectedEvent.social_image);
   expect(actualReturned.admission_fee).toEqual(expectedEvent.admission_fee);
-  expect(actualReturned.organizer_contact).toEqual(
-    expectedEvent.organizer_contact,
-  );
+
+  if (compareAuthenticatedUser) {
+    expect(actualReturned.organizer_contact).toEqual(
+      expectedEvent.organizer_contact,
+    );
+  } else {
+    // we filter organizer contact on un-authenticated endpoints, in such cases it should be undefined
+    expect(actualReturned.organizer_contact).toEqual(undefined);
+  }
+
   expect(actualReturned.brief_description).toEqual(
     expectedEvent.brief_description,
   );


### PR DESCRIPTION
Addresses issue #481 - when ids were used for events that did not exist instead of returning a 404 we were getting a null pointer exception and returning 500. This doesn't hurt much but makes are logs look scarier than they need be :-)

Also including a one line fix for issue #485 which was noticed while inspecting logs. There is a spot in our log lines which was intended to include the env setting but was instead hard coded to TEST, making it look like prod was misconfigured.