### PR TITLE
Duplicate Detection For Event Editing -- issue #491, issue #489

### DIFF
--- a/api-server/src/events/dto/existing-event-detection-parameters.ts
+++ b/api-server/src/events/dto/existing-event-detection-parameters.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsOptional } from 'class-validator';
 
 const EXAMPLE_DATE = new Date();
 
@@ -15,6 +15,15 @@ export default class ExistingEventDetectionParameters {
   })
   @IsNotEmpty()
   timeAndLocations: TimeAndLocationSearchParameters[];
+
+  @ApiProperty({
+    required: false,
+    example: ['dfef2ffe-0eed-4049-af94-cabf46852417'],
+    description:
+      'used to exclude some issues from matching, for example the issue currently presented to the user',
+  })
+  @IsOptional()
+  excludeIds?: string[];
 }
 
 export class TimeAndLocationSearchParameters {

--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -82,7 +82,6 @@
           <v-expansion-panel expand v-model="showDateTimePicker">
             <v-expansion-panel-content>
               <date-time-picker v-model="calendar_event.date_times" :mode="user_action" @change="onDateTimeVenueChanged" />
-
             </v-expansion-panel-content>
           </v-expansion-panel>
         </v-flex>

--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -413,6 +413,9 @@
         tags: new_event.tags ? new_event.tags.map(t => t) : []
       })
     },
+    mounted() {
+      this.doTimeAndLocationExistingEventDetection()
+    },
     methods: {
       /** @public */
       isDirty: function () {
@@ -552,6 +555,11 @@
             venueId: venueId,
             startTime: start_time
           }))
+        }
+
+        if (typeof this.calendar_event.id === 'string' && this.calendar_event.id.trim().length !== 0) {
+          // if we are editing an existing event, exclude that even from duplicate detection
+          duplicateDetectionPayload.excludeIds = [this.calendar_event.id]
         }
 
         this.$apiService.post('/events/detect-existing/by-time-and-location', duplicateDetectionPayload)

--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -684,7 +684,7 @@
           this.calendar_event.brief_description !== ''
       },
       isAdmin: function () {
-        return this.$auth.loggedIn && this.$store.getters.IsUserAdmin
+        return this.$auth && this.$auth.loggedIn && this.$store.getters.IsUserAdmin
       },
       shouldShowExistingEventDetectionByStartTime: function () {
         return this.duplicateEventsByStartTime !== null &&

--- a/web-portal/pages/admin-event-edit/_id/index.vue
+++ b/web-portal/pages/admin-event-edit/_id/index.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="container admin-page">
-    <v-app>
+    <div v-if="$store.getters.GetUserDataLoading">
+      loading...
+    </div>
+
+    <v-app v-if="!$store.getters.GetUserDataLoading">
       <client-only>
         <submission-form :user_action="'edit'" :user_role="'admin'" :event_id="id"></submission-form>
       </client-only>

--- a/web-portal/store/index.js
+++ b/web-portal/store/index.js
@@ -13,6 +13,9 @@ export const state = () => {
     calendar_event: {},
 
     user_data: {},
+    user_data_loading: true,
+    user_data_error: null,
+
     loaded_from_api: false,
 
     all_local_events: [],
@@ -60,6 +63,14 @@ export const getters = {
     return state.user_data
   },
 
+  GetUserDataLoading: (state) => {
+    return state.user_data_loading
+  },
+
+  GetUserDataError: (state) => {
+    return state.user_data_error
+  },
+
   IsUserAdmin: (state) => {
     return !!state.user_data && state.user_data.isInfiniteAdmin
   }
@@ -72,7 +83,19 @@ export const mutations = {
 
   UPDATE_USER_DATA: (state, userData) => {
     state.user_data = { ...userData }
+    state.user_data_loading = false
+    state.user_data_error = null
     state.loaded_from_api = true
+  },
+
+  USER_DATA_FETCH_START: (state) => {
+    state.user_data_loading = true
+    state.user_data_error = null
+  },
+
+  USER_DATA_FETCH_FAIL: (state, err) => {
+    state.user_data_loading = false
+    state.user_data_error = err
   },
 
   POPULATE_CURRENT_EVENT: (state, payload) => {
@@ -107,9 +130,15 @@ export const actions = {
   },
 
   LoadAllUserData: function (context, payload) {
+    context.commit('USER_DATA_FETCH_START')
+
     return this.$apiService.get('/users/current', payload.idToken)
       .then(function (_response) {
         context.commit('UPDATE_USER_DATA', _response.data)
+      }).catch((ex) => {
+        context.commit('USER_DATA_FETCH_FAIL', ex)
+
+        throw ex
       })
   },
   LoadAllLocalEventData: function (context) {


### PR DESCRIPTION
So that duplicates can be discovered when approving an event we would like to enable it durring issue editing. Three bugs were getting in the way.

1. The duplicate detection was not being triggered on initial form load
2. The state used to determine if the user was an admin was not available on the initial form load
3. The duplicate detection api did not have a way to exclude issues, such as the one you are currently viewing

This pr corrects the two bugs and adds the ability to exclude the issue being edited from detection