### PR TITLE
Updated Edit button on Admin Event List

### DIFF
--- a/e2e-tests/integration/eventEditingTest.js
+++ b/e2e-tests/integration/eventEditingTest.js
@@ -97,7 +97,7 @@ context('Event editing:', () => {
 
     // verify event is gone
     cy.location('pathname').should('not.include', 'admin-event-edit/')
-    cy.contains('.unverified-events tr td a[href$="admin-event-edit/' + EVENT_ID + '"]').should('not.exist')
+    cy.contains(`.unverified-events tr td button[data-test-id="edit-issue-button-${EVENT_ID}"]`).should('not.exist')
   })
 
   it('Title can be modified', () => {
@@ -105,7 +105,7 @@ context('Event editing:', () => {
 
     // find and open event
     cy.visitAsUser(ADMIN_USERNAME, ADMIN_PASSWORD, '/admin')
-    cy.get('.unverified-events tr td a[href$="admin-event-edit/' + EVENT_ID + '"]').click()
+    cy.get(`.unverified-events tr td button[data-test-id="edit-issue-button-${EVENT_ID}"]`).click()
     cy.location('pathname').should('include', 'admin-event-edit')
 
     // modify its title, wait for it to save

--- a/e2e-tests/integration/eventSubmissionTest.js
+++ b/e2e-tests/integration/eventSubmissionTest.js
@@ -109,7 +109,7 @@ context('Event Submission', () => {
     cy.get('#nav-list li').contains('Admin').click()
     cy.location('pathname').should('include', 'admin')
     cy.contains('.unverified-events tr:first-child td', EVENT_NAME)
-    cy.get('.unverified-events tr:first-child a').contains('Edit').click()
+    cy.get('.unverified-events tr:first-child button').contains('Edit').click()
     cy.location('pathname').should('include', 'admin-event-edit')
     cy.get('.submitter-email input').should('have.value', EVENT_EMAIL)
 

--- a/web-portal/components/AdminEventsList.vue
+++ b/web-portal/components/AdminEventsList.vue
@@ -22,6 +22,7 @@
           <ii-form-button
             style-type="light"
             @click="onEditClicked(calendar_event.id)"
+            :test-id="'edit-issue-button-' + calendar_event.id"
           >
             Edit
           </ii-form-button>

--- a/web-portal/components/AdminEventsList.vue
+++ b/web-portal/components/AdminEventsList.vue
@@ -18,7 +18,14 @@
           <small v-if="calendar_event.date_times.length > 2">(and {{ calendar_event.date_times.length - 2 }} more)</small>
           <template v-if="calendar_event.category && calendar_event.category==='online-resource'">Online Resource</template>
         </td>
-        <td><v-btn nuxt :to="{ name: 'admin-event-edit-id', params: { id: calendar_event.id } }">Edit</v-btn></td>
+        <td>
+          <ii-form-button
+            style-type="light"
+            @click="onEditClicked(calendar_event.id)"
+          >
+            Edit
+          </ii-form-button>
+        </td>
         <td>
           <input
             type="checkbox"
@@ -37,9 +44,13 @@
   import PartnerService from '@/services/PartnerService'
   import { UPSERT_ADMIN_EVENT_METADATA } from '../store/event-admin-metadata'
   import getToken from '../helpers/getToken'
+  import FormButton from '@/components/FormButton.vue'
 
   export default {
     name: 'AdminEventsList',
+    components: {
+      'ii-form-button': FormButton
+    },
     props: ['calendar_events'],
     data: function () {
       return {
@@ -79,6 +90,9 @@
           UPSERT_ADMIN_EVENT_METADATA,
           { eventId: id, isProblem: event.currentTarget.checked, idToken }
         )
+      },
+      onEditClicked(eventId) {
+        this.$router.push({ name: 'admin-event-edit-id', params: { id: eventId } })
       }
     }
   }

--- a/web-portal/components/FormButton.vue
+++ b/web-portal/components/FormButton.vue
@@ -29,7 +29,10 @@
 
         if (this.styleType === 'default') {
           classes.push('ii-form-button_default')
+        } else if (this.styleType === 'light') {
+          classes.push('ii-form-button_light')
         }
+
         return classes
       }
     }
@@ -75,4 +78,12 @@
  .ii-form-button_default:hover {
    background-color: #8d8d8d
  }
+
+  .ii-form-button_light {
+    background-color: #f5f5f5
+  }
+
+  .ii-form-button_light:hover {
+    background-color: #dbdbdb;
+  }
 </style>

--- a/web-portal/components/FormButton.vue
+++ b/web-portal/components/FormButton.vue
@@ -3,6 +3,7 @@
     :class="classes"
     @click="$emit('click', ...arguments)"
     :type="type"
+    :data-test-id="testId"
   >
     <slot></slot>
   </button>
@@ -18,6 +19,10 @@
       styleType: {
         type: String,
         default: 'default'
+      },
+      testId: {
+        type: String,
+        default: ''
       }
     },
     model: {

--- a/web-portal/test/AdminEventsList.spec.js
+++ b/web-portal/test/AdminEventsList.spec.js
@@ -1,10 +1,7 @@
-import Vuetify from 'vuetify'
-
 import { createLocalVue, RouterLinkStub, mount } from '@vue/test-utils'
 import AdminEventsList from '@/components/AdminEventsList.vue'
 
 const localVue = createLocalVue()
-localVue.use(Vuetify)
 
 const getEventList = () => {
   return [

--- a/web-portal/test/Logo.spec.js
+++ b/web-portal/test/Logo.spec.js
@@ -1,9 +1,10 @@
-import { mount } from '@vue/test-utils'
+import { mount, RouterLinkStub } from '@vue/test-utils'
 import Logo from '@/components/vectors/Logo.vue'
 
 describe('Logo', () => {
   test('is a Vue instance', () => {
-    const wrapper = mount(Logo)
+    const wrapper = mount(Logo, { stubs: { NuxtLink: RouterLinkStub } })
+
     expect(wrapper.vm).toBeTruthy()
   })
 })

--- a/web-portal/test/SubmissionForm.spec.js
+++ b/web-portal/test/SubmissionForm.spec.js
@@ -3,11 +3,13 @@ import Vuex from 'vuex'
 import { createLocalVue, shallowMount } from '@vue/test-utils'
 import SubmissionForm from '../components/SubmissionForm'
 import { getEmptyCalendarEvent } from '../services/ResourceTemplateService'
+import Vuetify from 'vuetify'
 
 jest.mock('@/services/ImageUploadService')
 
 const localVue = createLocalVue()
 localVue.use(Vuex)
+localVue.use(Vuetify)
 
 /**
  * When submission was refactored (Nov 2021) the only test case here


### PR DESCRIPTION
Updated the Edit button on the admin event list page to no longer use vuetify

I also added localVue.use(Vuetify) line to the SubmissionForm spec so that several warnings would go away. This does still call one warning about multiple versions of vue being used. This seems like a bug in our vuetify version, but hey it's going away soon. One warning seems better than however many were happing before.

I also removed localVue.use(Vuietify) from the AdminEventList.spec.js file where it's no longer needed. This kills another warning about multiple vue versions

I added a stub to Logo.spec.js to get rid of another test warning