### PR TITLE
Add analytics gathering for brief description suggestions

### DIFF
--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -199,6 +199,7 @@
             v-model="calendar_event.brief_description"
             :loading="loadingSuggestedBriefDescription"
             :messages="showingSuggestedBriefDescription ? 'This summary was generated from your full description using AI. Feel free to edit or replace it.' : ''"
+            @change="showingSuggestedBriefDescription = false"
           />
         </v-flex>
       </v-layout>
@@ -464,7 +465,7 @@
           this.submissionError = error
         })
 
-        this.recordSuggestedTags()
+        this.recordSuggestions()
       },
       ConfirmDeleteEvent: function () {
         this.dialog = true
@@ -530,7 +531,7 @@
 
           return this.$apiService.post('/events', event)
         }).then((response) => {
-          return this.recordSuggestedTags(response.data?.id)
+          return this.recordSuggestions(response.data?.id)
         }).then((response) => {
           this.showEventLoadingSpinner = false
           this.$emit('submitted')
@@ -695,12 +696,12 @@
             })
         }
       },
-      recordSuggestedTags(eventId) {
-        if (this.rawSuggestedTags) {
+      recordSuggestions(eventId) {
+        if (this.rawSuggestedTags || this.rawSuggestedBriefDescription) {
           return this.$suggestionService.submitFeedback(
-            this.rawSuggestedTags,
-            this.calendar_event.tags,
-            eventId || this.calendar_event.id
+            { tags: this.rawSuggestedTags, summary: this.rawSuggestedBriefDescription },
+            { tags: this.calendar_event.tags, summary: this.calendar_event.brief_description },
+            eventId
           )
         } else return Promise.resolve()
       }

--- a/web-portal/internal-api/slack-analytics.js
+++ b/web-portal/internal-api/slack-analytics.js
@@ -12,11 +12,27 @@ export const ENV = process.env.ENV || 'dev'
 export default async function slackAnalyticsHandler(req, res) {
   logger.info('JavaScript HTTP trigger (analytics) function processed a request.')
 
+  // deprecated now that we're also tracking brief description/"summary";
+  // prefer "suggestion-feedback"
   if (req.method === 'POST' && req.url.match(/\/?tag-feedback/i)) {
     logger.info('Processing tag generation feedback')
     if (req.body.suggested && req.body.submitted) {
       try {
-        await PostToSlack(req.body.suggested, req.body.submitted, req.body.eventId)
+        await PostToSlack('tag-feedback', req.body.suggested, req.body.submitted, req.body.eventId)
+      } catch (e) {
+        logger.error(e)
+        res.statusCode = 500
+        return res.end()
+      }
+    } else {
+      res.statusCode = 400
+      return res.end()
+    }
+  } else if (req.method === 'POST' && req.url.match(/\/?suggestion-feedback/i)) {
+    logger.info('Processing submission suggestion feedback')
+    if (req.body.suggested && req.body.submitted) {
+      try {
+        await PostToSlack('suggestion-feedback', req.body.suggested, req.body.submitted, req.body.eventId)
       } catch (e) {
         logger.error(e)
         res.statusCode = 500
@@ -34,10 +50,10 @@ export default async function slackAnalyticsHandler(req, res) {
   res.end()
 }
 
-function PostToSlack(suggested, submitted, eventId) {
+function PostToSlack(type, suggested, submitted, eventId) {
   return new Promise((resolve, reject) => {
     const message = JSON.stringify({
-      type: 'tag-feedback',
+      type,
       env: ENV,
       suggested,
       submitted,

--- a/web-portal/plugins/suggestion-service-plugin.js
+++ b/web-portal/plugins/suggestion-service-plugin.js
@@ -51,6 +51,6 @@ class SuggestionService {
   }
 
   async submitFeedback(suggested, submitted, eventId) {
-    await axios.post('/internal-api/analytics/tag-feedback', { suggested, submitted, eventId })
+    await axios.post('/internal-api/analytics/suggestion-feedback', { suggested, submitted, eventId })
   }
 }


### PR DESCRIPTION
Refactors "internal API" endpoint on web portal to receive brief description feedback along with tags

Renames some of the frontend handling to reflect that it's not just tag feedback.

Structure posted in Slack will now be

```json
{
  "type": "suggestion-feedback",
  "env": "dev | staging | prod",
  "suggested": {
    "tags": [],
    "summary": ""
  },
  "submitted": {
    "tags": [],
    "summary": ""
  }
}
```