### PR TITLE
Error handling enhancement for analytics

### DIFF
--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -526,36 +526,33 @@
           reviewed_by_org: this.reviewOrg ? this.reviewOrg : null
         }
 
-        const result = await this.$apiService.uploadEventImage(this.$refs.eventImage.files[0]).then((response) => {
-          event.image = response.data.imagePath
-
-          return this.$apiService.post('/events', event)
-        })
-          .then((response) => {
-            this.showEventLoadingSpinner = false
-            this.$emit('submitted')
-
-            return response
-          }).catch((error) => {
-            console.error('error uploading image:', error)
-
-            this.showEventLoadingSpinner = false
-            this.eventSubmitted = false
-
-            this.$emit('error', { error })
-
-            return null
-          })
+        let eventCreationResponse = null
 
         try {
-          if (result !== null) {
-            await this.recordSuggestions(result.data?.id)
+          const uploadImageResponse = await this.$apiService.uploadEventImage(this.$refs.eventImage.files[0])
+          event.image = uploadImageResponse.data.imagePath
+
+          eventCreationResponse = await this.$apiService.post('/events', event)
+          this.showEventLoadingSpinner = false
+          this.$emit('submitted')
+        } catch (error) {
+          console.error('error uploading image:', error)
+
+          this.showEventLoadingSpinner = false
+          this.eventSubmitted = false
+
+          this.$emit('error', { error })
+        }
+
+        try {
+          if (eventCreationResponse !== null) {
+            await this.recordSuggestions(eventCreationResponse.data?.id)
           }
         } catch (ex) {
           console.warn('could not submit tag analytics: ' + ex)
         }
 
-        return result
+        return eventCreationResponse
       },
       selectVenue: function (venue) {
         this.calendar_event.venue_id = venue.id

--- a/web-portal/internal-api/slack-analytics.js
+++ b/web-portal/internal-api/slack-analytics.js
@@ -46,16 +46,17 @@ function PostToSlack(suggested, submitted, eventId) {
 
     // slack-notify doesn't handle this gracefully
     // hopefully it isn't necessary in production but in dev it's useful
-    if (!SLACK_WEBHOOK_ANALYTICS) {
-      return reject(new Error('No Slack URL configured'))
+    if (SLACK_WEBHOOK_ANALYTICS) {
+      contactChannel.send({
+        channel: 'analytics',
+        icon_emoji: ':computer:',
+        text: message
+      })
+        .then(() => resolve('Message received!'))
+        .catch(err => reject(new Error('API error:' + err)))
+    } else {
+      console.warn('slack webhooks are not enabled -- no analytics sent')
+      resolve()
     }
-
-    contactChannel.send({
-      channel: 'analytics',
-      icon_emoji: ':computer:',
-      text: message
-    })
-      .then(() => resolve('Message received!'))
-      .catch(err => reject(new Error('API error:' + err)))
   })
 }


### PR DESCRIPTION
handle analytics failures more correctly

* a failure of the client to sumbit generated vs selected tags should not stop the form
  from showing success on submission of an event
* the web-portal internal api should not return 500 if web hooks are enabled, it should simply
  log a warning to the conolse and return 200