### PR TITLE
Fix styling on admin tables

### DIFF
--- a/web-portal/components/AdminEventsList.vue
+++ b/web-portal/components/AdminEventsList.vue
@@ -69,12 +69,12 @@
     font-family: "Open Sans", sans-serif;
   }
 
-  .calendar-events-table td, .calendar-events-table th {
+  .calendar-events-table >>> td, .calendar-events-table th {
       border: 1px solid #ddd;
       padding: 8px;
   }
 
-  .calendar-events-table td:first-child {
+  .calendar-events-table >>> td:first-child {
     text-align: center;
   }
 


### PR DESCRIPTION
The event tables in admin looked off when I logged in to fix something, and I realized we forgot to check that the styling wasn't affected by breaking the rows out into their own component.

The `scoped` style blocks don't affect descendant components unless you explicitly "break out" of them using `>>>` (or an equivalent operator, this is hard to find in the docs and I've never been clear on which of 3 or so different ways to do it is the right/least-wrong way).

Follow-up to #501