### PR TITLE
Update workflows to prevent errors

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           PORT: 3003
       - name: Save server logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if : ${{ failure() }}
         with:
           name: server-logs

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -76,7 +76,7 @@ jobs:
           ENV_US: "test"
           ENV_PW: "xxx"
       - name: Save Cypress artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: cypress-artifacts
@@ -90,7 +90,7 @@ jobs:
           docker logs $(docker ps -a --filter name=infinite_web-portal --format "{{.ID}}") &> ./web-portal.log
           docker logs $(docker ps -a --filter name=infinite_api-server --format "{{.ID}}") &> ./api-server.log
       - name: Save log artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: docker-artifacts


### PR DESCRIPTION
Github has deprecated the version of the artifact upload job we use, causing errors when the workflows run.