### PR TITLE
Implement Partner Work Flows on API - Part I

### DIFF
--- a/api-server/migrations/20250921184342-create-partners-table.js
+++ b/api-server/migrations/20250921184342-create-partners-table.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.createTable('partners', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()')
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      logo_url: {
+        type: Sequelize.STRING,
+        allowNull: true
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('now()')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('now()')
+      }
+    });
+
+    // Add a unique index on the name column with case-insensitivity
+    await queryInterface.addIndex('partners', {
+      fields: [Sequelize.fn('lower', Sequelize.col('name'))],
+      unique: true,
+      name: 'partners_name_lowercase_unique'
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('partners');
+  }
+};

--- a/api-server/migrations/20250921214442-create-users-partners-mappings.js
+++ b/api-server/migrations/20250921214442-create-users-partners-mappings.js
@@ -1,0 +1,67 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.createTable('users_partners_mappings', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()')
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      partner_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'partners',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('now()')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('now()')
+      }
+    });
+
+    // Add a composite unique constraint to prevent duplicate user-partner mappings
+    await queryInterface.addConstraint('users_partners_mappings', {
+      fields: ['user_id', 'partner_id'],
+      type: 'unique',
+      name: 'unique_user_partner_mapping'
+    });
+
+    // Add indexes for better query performance
+    await queryInterface.addIndex('users_partners_mappings', {
+      fields: ['user_id'],
+      name: 'idx_users_partners_mappings_user_id'
+    });
+
+    await queryInterface.addIndex('users_partners_mappings', {
+      fields: ['partner_id'],
+      name: 'idx_users_partners_mappings_partner_id'
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('users_partners_mappings');
+  }
+};

--- a/api-server/migrations/20250924002859-add-owning-partner-id-to-events.js
+++ b/api-server/migrations/20250924002859-add-owning-partner-id-to-events.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('events', 'owning_partner_id', {
+      type: Sequelize.UUID,
+      allowNull: true,
+      references: {
+        model: 'partners',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL'
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('events', 'owning_partner_id');
+  }
+};

--- a/api-server/src/announcements/announcements.controller.ts
+++ b/api-server/src/announcements/announcements.controller.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/common';
 import { VERSION_1_URI } from '../utils/versionts';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import { AdminAuthGuard } from '../authentication/AdminAuth.guard';
+import { AdminAuthGuard } from '../authentication/auth-guards/admin-auth.guard';
 import { AnnouncementsService } from './announcements.service';
 import { CreateOrUpdateAnnouncementRequest } from './dto/create-or-update-announcement-request';
 import { AnnouncementResponse } from './dto/announcement-response';

--- a/api-server/src/announcements/announcements.controller.ts
+++ b/api-server/src/announcements/announcements.controller.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/common';
 import { VERSION_1_URI } from '../utils/versionts';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import { AuthGuard } from '../authentication/auth.guard';
+import { AdminAuthGuard } from '../authentication/AdminAuth.guard';
 import { AnnouncementsService } from './announcements.service';
 import { CreateOrUpdateAnnouncementRequest } from './dto/create-or-update-announcement-request';
 import { AnnouncementResponse } from './dto/announcement-response';
@@ -31,7 +31,7 @@ export class AnnouncementsController {
   }
 
   @Post('/ensure-one-announcement')
-  @UseGuards(AuthGuard)
+  @UseGuards(AdminAuthGuard)
   @ApiOperation({
     summary:
       'Create an announcement if it does not exist or update the current one if present.',
@@ -48,7 +48,7 @@ export class AnnouncementsController {
   }
 
   @Put('/:id')
-  @UseGuards(AuthGuard)
+  @UseGuards(AdminAuthGuard)
   @ApiOperation({ summary: 'update an existing announcement' })
   updateAnnouncement(
     @Param() params: FindByIdParams,

--- a/api-server/src/announcements/announcements.module.ts
+++ b/api-server/src/announcements/announcements.module.ts
@@ -3,10 +3,15 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { AnnouncementModel } from './models/announcement.model';
 import { AnnouncementsController } from './announcements.controller';
 import { AnnouncementsService } from './announcements.service';
+import UsersService from '../users/users.service';
+import { UserModel } from '../users/models/user.model';
+import { VenueModel } from '../venues/models/venue.model';
 
 @Module({
-  imports: [SequelizeModule.forFeature([AnnouncementModel])],
+  imports: [
+    SequelizeModule.forFeature([AnnouncementModel, UserModel, VenueModel]),
+  ],
   controllers: [AnnouncementsController],
-  providers: [AnnouncementsService],
+  providers: [AnnouncementsService, UsersService],
 })
 export class AnnouncementsModule {}

--- a/api-server/src/app.module.ts
+++ b/api-server/src/app.module.ts
@@ -91,7 +91,9 @@ const dialectOptions = SQL_IS_USING_SSL
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
-      .apply(UserInformationMiddleware, LoggingMiddleware) // both apply to all routes
+      // for all routes, including root, attach user information to the request
+      // and run request logging middleware
+      .apply(UserInformationMiddleware, LoggingMiddleware)
       .forRoutes('*');
   }
 }

--- a/api-server/src/app.module.ts
+++ b/api-server/src/app.module.ts
@@ -91,9 +91,7 @@ const dialectOptions = SQL_IS_USING_SSL
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
-      .apply(UserInformationMiddleware) // attaches userInformation to the Request object
-      .forRoutes('*')
-      .apply(LoggingMiddleware)
-      .forRoutes('/**');
+      .apply(UserInformationMiddleware, LoggingMiddleware) // both apply to all routes
+      .forRoutes('*');
   }
 }

--- a/api-server/src/app.module.ts
+++ b/api-server/src/app.module.ts
@@ -6,6 +6,7 @@ import { AnnouncementsModule } from './announcements/announcements.module';
 import { UsersModules } from './users/users.modules';
 import { NotificationsModule } from './notifications/notifications.module';
 import LoggingMiddleware from './logging/logging.middleware';
+import { UserInformationMiddleware } from './authentication/user-information.middleware';
 import { WinstonModule } from 'nest-winston';
 import { format, transports } from 'winston';
 import { CalendaringModule } from './calendaring/calendaring.module';
@@ -84,10 +85,15 @@ const dialectOptions = SQL_IS_USING_SSL
       provide: APP_FILTER,
       useClass: ExceptionLogger,
     },
+    UserInformationMiddleware,
   ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(LoggingMiddleware).forRoutes('/**');
+    consumer
+      .apply(UserInformationMiddleware) // attaches userInformation to the Request object
+      .forRoutes('*')
+      .apply(LoggingMiddleware)
+      .forRoutes('/**');
   }
 }

--- a/api-server/src/authentication/AdminAuth.guard.ts
+++ b/api-server/src/authentication/AdminAuth.guard.ts
@@ -8,20 +8,23 @@ import {
   LoggerService,
 } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { parseJwt, UserInformation } from './parse-jwt';
+import UsersService from '../users/users.service';
 
 @Injectable()
 export class AdminAuthGuard implements CanActivate {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService,
+    private readonly userService: UsersService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
 
     try {
-      const userInformation: UserInformation = await parseJwt(request);
+      const userInformation = await this.userService.ensureCurrentUserByName(
+        request,
+      );
 
       request.userInformation = userInformation;
 

--- a/api-server/src/authentication/AdminAuth.guard.ts
+++ b/api-server/src/authentication/AdminAuth.guard.ts
@@ -11,7 +11,7 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { parseJwt, UserInformation } from './parse-jwt';
 
 @Injectable()
-export class AuthGuard implements CanActivate {
+export class AdminAuthGuard implements CanActivate {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService,

--- a/api-server/src/authentication/AdminAuth.guard.ts
+++ b/api-server/src/authentication/AdminAuth.guard.ts
@@ -1,37 +1,11 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  HttpException,
-  HttpStatus,
-  Inject,
-  Injectable,
-  LoggerService,
-} from '@nestjs/common';
-import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import UsersService from '../users/users.service';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { RequestWithUserInfo } from '../users/dto/RequestWithUserInfo';
 
 @Injectable()
 export class AdminAuthGuard implements CanActivate {
-  constructor(
-    @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: LoggerService,
-    private readonly userService: UsersService,
-  ) {}
-
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest();
-
-    try {
-      const userInformation = await this.userService.ensureCurrentUserByName(
-        request,
-      );
-
-      request.userInformation = userInformation;
-
-      return userInformation.isInfiniteAdmin;
-    } catch (ex) {
-      this.logger.error(ex);
-      throw new HttpException('invalid auth token', HttpStatus.FORBIDDEN);
-    }
+    // user information set by user-information.middleware
+    const request: RequestWithUserInfo = context.switchToHttp().getRequest();
+    return request.userInformation?.isInfiniteAdmin;
   }
 }

--- a/api-server/src/authentication/PartnerAdmin.guard.ts
+++ b/api-server/src/authentication/PartnerAdmin.guard.ts
@@ -1,8 +1,6 @@
 import {
   CanActivate,
   ExecutionContext,
-  HttpException,
-  HttpStatus,
   Inject,
   Injectable,
   LoggerService,
@@ -20,18 +18,9 @@ export class PartnerAdminGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
-
-    try {
-      const userInformation = await this.userService.ensureCurrentUserByName(
-        request,
-      );
-
-      request.userInformation = userInformation;
-
-      return userInformation.isInfiniteAdmin || userInformation.isOwnerAdmin;
-    } catch (ex) {
-      this.logger.error(ex);
-      throw new HttpException('invalid auth token', HttpStatus.FORBIDDEN);
-    }
+    return (
+      request.userInformation?.isInfiniteAdmin ||
+      request.userInformation?.isPartnerAdmin
+    );
   }
 }

--- a/api-server/src/authentication/PartnerAdmin.guard.ts
+++ b/api-server/src/authentication/PartnerAdmin.guard.ts
@@ -1,0 +1,37 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  LoggerService,
+} from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import UsersService from '../users/users.service';
+
+@Injectable()
+export class PartnerAdminGuard implements CanActivate {
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService,
+    private readonly userService: UsersService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    try {
+      const userInformation = await this.userService.ensureCurrentUserByName(
+        request,
+      );
+
+      request.userInformation = userInformation;
+
+      return userInformation.isInfiniteAdmin || userInformation.isOwnerAdmin;
+    } catch (ex) {
+      this.logger.error(ex);
+      throw new HttpException('invalid auth token', HttpStatus.FORBIDDEN);
+    }
+  }
+}

--- a/api-server/src/authentication/auth-guards/admin-auth.guard.ts
+++ b/api-server/src/authentication/auth-guards/admin-auth.guard.ts
@@ -1,5 +1,5 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
-import { RequestWithUserInfo } from '../users/dto/RequestWithUserInfo';
+import { RequestWithUserInfo } from '../../users/dto/RequestWithUserInfo';
 
 @Injectable()
 export class AdminAuthGuard implements CanActivate {

--- a/api-server/src/authentication/auth-guards/authenticated-user.guard.ts
+++ b/api-server/src/authentication/auth-guards/authenticated-user.guard.ts
@@ -1,5 +1,5 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
-import isNotNullOrUndefined from '../utils/is-not-null-or-undefined';
+import isNotNullOrUndefined from '../../utils/is-not-null-or-undefined';
 
 // Only check if user is authenticated, not if they're admin
 @Injectable()

--- a/api-server/src/authentication/auth-guards/partner-admin.guard.ts
+++ b/api-server/src/authentication/auth-guards/partner-admin.guard.ts
@@ -6,7 +6,7 @@ import {
   LoggerService,
 } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import UsersService from '../users/users.service';
+import UsersService from '../../users/users.service';
 
 @Injectable()
 export class PartnerAdminGuard implements CanActivate {

--- a/api-server/src/authentication/authenticated-user.guard.ts
+++ b/api-server/src/authentication/authenticated-user.guard.ts
@@ -1,39 +1,11 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  HttpException,
-  HttpStatus,
-  Inject,
-  Injectable,
-  LoggerService,
-} from '@nestjs/common';
-import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import isNotNullOrUndefined from '../utils/is-not-null-or-undefined';
-import UsersService from '../users/users.service';
 
 // Only check if user is authenticated, not if they're admin
 @Injectable()
 export class AuthenticatedUserGuard implements CanActivate {
-  constructor(
-    @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: LoggerService,
-    private userService: UsersService,
-  ) {}
-
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
-
-    try {
-      const userInformation = await this.userService.ensureCurrentUserByName(
-        request,
-      );
-
-      request.userInformation = userInformation;
-
-      return isNotNullOrUndefined(userInformation);
-    } catch (ex) {
-      this.logger.error(ex);
-      throw new HttpException('invalid auth token', HttpStatus.FORBIDDEN);
-    }
+    return isNotNullOrUndefined(request.userInformation);
   }
 }

--- a/api-server/src/authentication/authenticated-user.guard.ts
+++ b/api-server/src/authentication/authenticated-user.guard.ts
@@ -1,0 +1,35 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  LoggerService,
+} from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { parseJwt, UserInformation } from './parse-jwt';
+
+@Injectable()
+export class AuthenticatedUserGuard implements CanActivate {
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    try {
+      const userInformation: UserInformation = await parseJwt(request);
+
+      request.userInformation = userInformation;
+
+      // Only check if user is authenticated, not if they're admin
+      return true;
+    } catch (ex) {
+      this.logger.error(ex);
+      throw new HttpException('invalid auth token', HttpStatus.FORBIDDEN);
+    }
+  }
+}

--- a/api-server/src/authentication/filters/remove-sensitive-data-for-non-admins.ts
+++ b/api-server/src/authentication/filters/remove-sensitive-data-for-non-admins.ts
@@ -1,5 +1,3 @@
-import { Request } from 'express';
-import isAdminUser from '../is-admin-user';
 import EventDTO from '../../events/dto/eventDTO';
 import { RequestWithUserInfo } from '../../users/dto/RequestWithUserInfo';
 import isNotNullOrUndefined from '../../utils/is-not-null-or-undefined';

--- a/api-server/src/authentication/filters/remove-sensitive-data-for-non-admins.ts
+++ b/api-server/src/authentication/filters/remove-sensitive-data-for-non-admins.ts
@@ -1,34 +1,69 @@
 import { Request } from 'express';
 import isAdminUser from '../is-admin-user';
 import EventDTO from '../../events/dto/eventDTO';
+import { RequestWithUserInfo } from '../../users/dto/RequestWithUserInfo';
+import isNotNullOrUndefined from '../../utils/is-not-null-or-undefined';
 
 type EventOrEventList = EventDTO | EventDTO[];
 
 export async function removeSensitiveDataForNonAdmins<
   T extends EventOrEventList,
->(request: Request, events: T): Promise<T> {
-  const isAdmin = await isAdminUser(request);
+>(request: RequestWithUserInfo, events: T): Promise<T> {
+  const isAdmin = request.userInformation?.isInfiniteAdmin;
 
   if (isAdmin) {
+    // no filter for infinite admins
     return events;
   }
 
   if (isGenericEventList(events)) {
-    return removeSensitiveDataList(events) as T;
+    return removeSensitiveDataList(request, events) as T;
   } else {
-    return removeSensitiveDataForSingleEvent(events as EventDTO) as T;
+    return removeSensitiveDataForSingleEvent(request, events as EventDTO) as T;
   }
 }
 
-function removeSensitiveDataList(currentEvents: EventDTO[]): EventDTO[] {
+function removeSensitiveDataList(
+  request: RequestWithUserInfo,
+  currentEvents: EventDTO[],
+): EventDTO[] {
   if (currentEvents.length === 0) {
     return [];
   } else {
-    return currentEvents.map(removeSensitiveDataForSingleEvent);
+    return currentEvents.map((event) =>
+      removeSensitiveDataForSingleEvent(request, event),
+    );
   }
 }
 
-function removeSensitiveDataForSingleEvent(infiniteEvent: EventDTO): EventDTO {
+function removeSensitiveDataForSingleEvent(
+  request: RequestWithUserInfo,
+  infiniteEvent: EventDTO,
+): EventDTO {
+  const isPartnerAdmin = request.userInformation?.isPartnerAdmin;
+
+  if (isPartnerAdmin) {
+    // if the user is a partner admin check if this even belongs to them before
+    // filtering
+    console.log(
+      '!!! partners: ' +
+        JSON.stringify(request.userInformation.partners, null, 4),
+    );
+
+    const isOwner: boolean = isNotNullOrUndefined(
+      request.userInformation.partners.find(
+        (p) => p.id === infiniteEvent.owning_partner_id,
+      ),
+    );
+
+    if (isOwner) {
+      // they own it, just return the unfiltered event
+      return infiniteEvent;
+    }
+  }
+
+  // strip the organizer_contact, we keep this internal and don't expose
+  // it over the api or via the ui to un-authenticated users
   return { ...infiniteEvent, organizer_contact: undefined };
 }
 

--- a/api-server/src/authentication/is-admin-user.ts
+++ b/api-server/src/authentication/is-admin-user.ts
@@ -5,9 +5,6 @@ async function isAdminUser(req: Request): Promise<boolean> {
   try {
     const userInformation: UserInformation = await parseJwt(req);
 
-    console.log(
-      '!!! userInformation: ' + JSON.stringify(userInformation, null, 4),
-    );
     return userInformation.isInfiniteAdmin;
   } catch (ex) {
     return false;

--- a/api-server/src/authentication/is-admin-user.ts
+++ b/api-server/src/authentication/is-admin-user.ts
@@ -5,6 +5,9 @@ async function isAdminUser(req: Request): Promise<boolean> {
   try {
     const userInformation: UserInformation = await parseJwt(req);
 
+    console.log(
+      '!!! userInformation: ' + JSON.stringify(userInformation, null, 4),
+    );
     return userInformation.isInfiniteAdmin;
   } catch (ex) {
     return false;

--- a/api-server/src/authentication/parse-jwt.ts
+++ b/api-server/src/authentication/parse-jwt.ts
@@ -25,8 +25,7 @@ export interface DecodedAuthZeroToken extends Record<string, unknown> {
 }
 
 export function parseJwt(req: Request): Promise<UserInformation> {
-  const token =
-    req.body.token || req.query.token || req.headers['x-access-token'];
+  const token = getTokenFromHeader(req);
 
   return getUserInformationFromToken(token);
 }
@@ -51,4 +50,8 @@ function getUserInformationFromToken(token: string): Promise<UserInformation> {
       }
     });
   });
+}
+
+export function getTokenFromHeader(req: Request) {
+  return req.body.token || req.query.token || req.headers['x-access-token'];
 }

--- a/api-server/src/authentication/user-information.middleware.ts
+++ b/api-server/src/authentication/user-information.middleware.ts
@@ -1,0 +1,46 @@
+import {
+  Inject,
+  Injectable,
+  LoggerService,
+  NestMiddleware,
+} from '@nestjs/common';
+import { NextFunction, Response } from 'express';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import UsersService from '../users/users.service';
+import { RequestWithUserInfo } from '../users/dto/RequestWithUserInfo';
+
+/**
+ * User Information Middleware
+ *
+ * This middleware attempts to parse user information from the request token
+ * and attaches it to the request object. Unlike guards, this middleware:
+ * - Always allows the request to proceed (no access control)
+ * - Silently handles authentication failures
+ * - Sets userInformation to undefined if no valid token is present
+ *
+ */
+@Injectable()
+export class UserInformationMiddleware implements NestMiddleware {
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService,
+    private readonly userService: UsersService,
+  ) {}
+
+  async use(request: RequestWithUserInfo, res: Response, next: NextFunction) {
+    try {
+      this.logger.debug('running user-information middleware for request');
+      // Set userInformation on the request if we successfully parsed it
+      request.userInformation = await this.userService.ensureCurrentUserByName(
+        request,
+      );
+    } catch (ex) {
+      // We run this for all request authenticated or not, if there was parse
+      // error it was already logged and rethrown by ensureCurrentUserByName,
+      // we can ignore it here
+      this.logger.debug(`User information parsing failed: ${ex.message}`);
+    }
+
+    next();
+  }
+}

--- a/api-server/src/events/dto/create-event-request.ts
+++ b/api-server/src/events/dto/create-event-request.ts
@@ -85,9 +85,14 @@ export class CreateEventRequest {
   @IsOptional()
   bitly_link: string;
 
-  @ApiProperty({ example: 'radio-mc-radio-station' })
+  @ApiProperty({
+    example: 'radio-mc-radio-station',
+    description: `Associates this event with an existing partner. If an event
+    is associated with a partner then that partner then partner-admins will be
+    allowed to approve and mange this event. The partner must already exist.`,
+  })
   @IsOptional()
-  reviewed_by_org: string;
+  owning_partner_id: string;
 
   @ApiProperty({
     example: [{ start_time: EXAMPLE_START_DATE, end_time: EXAMPLE_END_DATE }],

--- a/api-server/src/events/dto/eventDTO.ts
+++ b/api-server/src/events/dto/eventDTO.ts
@@ -17,6 +17,9 @@ export default class EventDTO {
   @ApiProperty({ example: 'f467e7a0-a066-11ea-aa51-cdc3fe7afefa' })
   venue_id: string;
 
+  @ApiProperty({ example: 'f467e7a0-a066-11ea-aa51-cdc3fe7afefa', required: false })
+  owning_partner_id?: string;
+
   @ApiProperty({ example: 'Infinite Gallery Opening' })
   title: string;
 

--- a/api-server/src/events/dto/eventDTO.ts
+++ b/api-server/src/events/dto/eventDTO.ts
@@ -18,7 +18,10 @@ export default class EventDTO {
   @ApiProperty({ example: 'f467e7a0-a066-11ea-aa51-cdc3fe7afefa' })
   venue_id: string;
 
-  @ApiProperty({ example: 'f467e7a0-a066-11ea-aa51-cdc3fe7afefa', required: false })
+  @ApiProperty({
+    example: 'f467e7a0-a066-11ea-aa51-cdc3fe7afefa',
+    required: false,
+  })
   owning_partner_id?: string;
 
   @ApiProperty({ example: 'Infinite Gallery Opening' })
@@ -39,7 +42,12 @@ export default class EventDTO {
   @ApiProperty({ example: '5' })
   admission_fee: string;
 
-  @ApiProperty({ example: 'bob.vance@refridgeration.com' })
+  @ApiProperty({
+    description: `The e-mail address for admins of the site to communicate with
+    about the event. This will be filtered out of un-authenticated api calls. It
+    is meant for communication between the submitter and site admins`,
+    example: 'bob.vance@refridgeration.com',
+  })
   organizer_contact: string;
 
   @ApiProperty({ example: 'The gallery is open' })
@@ -101,8 +109,8 @@ export default class EventDTO {
   @ApiProperty()
   venue: VenueModel;
 
-  @ApiProperty({ 
-    type: () => PartnerDTO, 
+  @ApiProperty({
+    type: () => PartnerDTO,
     nullable: true,
     required: false,
     description: 'The partner that owns this event',
@@ -111,8 +119,8 @@ export default class EventDTO {
       name: 'TechCorp Inc.',
       logo_url: 'https://example.com/logo.png',
       createdAt: '2024-01-15T10:30:00.000Z',
-      updatedAt: '2024-01-15T10:30:00.000Z'
-    }
+      updatedAt: '2024-01-15T10:30:00.000Z',
+    },
   })
   owning_partner?: PartnerDTO;
 

--- a/api-server/src/events/dto/eventDTO.ts
+++ b/api-server/src/events/dto/eventDTO.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { VenueModel } from '../../venues/models/venue.model';
 import { StartEndTimePairs } from '../../shared-types/start-end-time-pairs';
+import { PartnerDTO } from '../../users/dto/partner-dto';
 
 const EXAMPLE_DATE = new Date();
 const EXAMPLE_START_DATE = new Date(
@@ -99,6 +100,21 @@ export default class EventDTO {
 
   @ApiProperty()
   venue: VenueModel;
+
+  @ApiProperty({ 
+    type: () => PartnerDTO, 
+    nullable: true,
+    required: false,
+    description: 'The partner that owns this event',
+    example: {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      name: 'TechCorp Inc.',
+      logo_url: 'https://example.com/logo.png',
+      createdAt: '2024-01-15T10:30:00.000Z',
+      updatedAt: '2024-01-15T10:30:00.000Z'
+    }
+  })
+  owning_partner?: PartnerDTO;
 
   @ApiProperty({
     example: {

--- a/api-server/src/events/dto/eventDTO.ts
+++ b/api-server/src/events/dto/eventDTO.ts
@@ -83,7 +83,10 @@ export default class EventDTO {
   @ApiProperty({ example: EXAMPLE_DATE })
   updatedAt: Date;
 
-  @ApiProperty({ example: 'radio-mc-radio-station' })
+  /**
+   * @deprecated This property is deprecated and will be removed in future versions.
+   */
+  @ApiProperty({ example: 'radio-mc-radio-station', deprecated: true })
   reviewed_by_org: string;
 
   @ApiProperty({

--- a/api-server/src/events/dto/eventModelToEventDTO.ts
+++ b/api-server/src/events/dto/eventModelToEventDTO.ts
@@ -2,6 +2,7 @@ import { EventModel } from '../models/event.model';
 import EventDTO from './eventDTO';
 import isNotNullOrUndefined from '../../utils/is-not-null-or-undefined';
 import { DatetimeVenueModel } from '../models/datetime-venue.model';
+import { PartnerDTO } from '../../users/dto/partner-dto';
 
 export function eventModelToEventDTO(eventModel: EventModel): EventDTO {
   const date_times: DatetimeVenueModel[] = isNotNullOrUndefined(
@@ -41,6 +42,7 @@ export function eventModelToEventDTO(eventModel: EventModel): EventDTO {
     title: eventModel.title,
     updatedAt: eventModel.updatedAt,
     venue_id: eventModel.venue_id,
+    owning_partner_id: eventModel.owning_partner_id,
     verified: eventModel.verified,
     website_link: eventModel.website_link,
     multi_day: eventModel.multi_day,
@@ -54,6 +56,15 @@ export function eventModelToEventDTO(eventModel: EventModel): EventDTO {
           createdAt: eventModel.event_admin_metadata.createdAt,
           updatedAt: eventModel.event_admin_metadata.updatedAt,
         }
+      : undefined,
+    owning_partner: isNotNullOrUndefined(eventModel.owning_partner)
+      ? new PartnerDTO({
+          id: eventModel.owning_partner.id,
+          name: eventModel.owning_partner.name,
+          logo_url: eventModel.owning_partner.logo_url,
+          createdAt: eventModel.owning_partner.createdAt,
+          updatedAt: eventModel.owning_partner.updatedAt,
+        })
       : undefined,
   };
 }

--- a/api-server/src/events/events.authenticated.controller.ts
+++ b/api-server/src/events/events.authenticated.controller.ts
@@ -43,7 +43,6 @@ import {
 import { validateAndExtractOptionalDateTimeFilters } from './utils/validateAndExtractOptionalDatetimeFilters';
 import { AuthenticatedUserGuard } from '../authentication/auth-guards/authenticated-user.guard';
 import { PartnerAdminGuard } from '../authentication/auth-guards/partner-admin.guard';
-import UsersService from '../users/users.service';
 import { RequestWithUserInfo } from '../users/dto/RequestWithUserInfo';
 import { Op } from 'sequelize';
 
@@ -53,10 +52,7 @@ import { Op } from 'sequelize';
 @ApiBearerAuth()
 @ApiResponse({ status: 403, description: 'Forbidden' })
 export default class EventsAuthenticatedController {
-  constructor(
-    private readonly eventsService: EventsService,
-    private readonly userService: UsersService,
-  ) {}
+  constructor(private readonly eventsService: EventsService) {}
 
   @Get()
   @UseGuards(AdminAuthGuard)

--- a/api-server/src/events/events.authenticated.controller.ts
+++ b/api-server/src/events/events.authenticated.controller.ts
@@ -17,7 +17,7 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { AdminAuthGuard } from '../authentication/AdminAuth.guard';
+import { AdminAuthGuard } from '../authentication/auth-guards/admin-auth.guard';
 import { EventIdResponse } from './dto/event-id-response';
 import { SingleEventResponse } from './dto/single-event-response';
 import { EventsService } from './events.service';
@@ -41,8 +41,8 @@ import {
   PaginationDto,
 } from './dto/pagination-dto';
 import { validateAndExtractOptionalDateTimeFilters } from './utils/validateAndExtractOptionalDatetimeFilters';
-import { AuthenticatedUserGuard } from '../authentication/authenticated-user.guard';
-import { PartnerAdminGuard } from '../authentication/PartnerAdmin.guard';
+import { AuthenticatedUserGuard } from '../authentication/auth-guards/authenticated-user.guard';
+import { PartnerAdminGuard } from '../authentication/auth-guards/partner-admin.guard';
 import UsersService from '../users/users.service';
 import { RequestWithUserInfo } from '../users/dto/RequestWithUserInfo';
 import { Op } from 'sequelize';

--- a/api-server/src/events/events.authenticated.controller.ts
+++ b/api-server/src/events/events.authenticated.controller.ts
@@ -16,7 +16,7 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { AuthGuard } from '../authentication/auth.guard';
+import { AdminAuthGuard } from '../authentication/AdminAuth.guard';
 import { EventIdResponse } from './dto/event-id-response';
 import { SingleEventResponse } from './dto/single-event-response';
 import { EventsService } from './events.service';
@@ -42,7 +42,7 @@ import {
 import { validateAndExtractOptionalDateTimeFilters } from './utils/validateAndExtractOptionalDatetimeFilters';
 
 @Controller(`${VERSION_1_URI}/authenticated/events`)
-@UseGuards(AuthGuard)
+@UseGuards(AdminAuthGuard)
 @ApiTags('events -- authenticated')
 @ApiBearerAuth()
 @ApiResponse({ status: 403, description: 'Forbidden' })

--- a/api-server/src/events/events.authenticated.controller.ts
+++ b/api-server/src/events/events.authenticated.controller.ts
@@ -101,6 +101,7 @@ export default class EventsAuthenticatedController {
     description: 'Filter events by category',
   })
   getAll(
+    @Req() request: RequestWithUserInfo,
     @Query('tags') tags: string[] | string = [],
     @Query('category') category: string,
     @Query() pagination: PaginationDto,
@@ -120,6 +121,7 @@ export default class EventsAuthenticatedController {
         verifiedOnly: false,
         startDate,
         endDate,
+        request,
       })
       .then((paginatedEventResp) => {
         const totalEntries = paginatedEventResp.count;

--- a/api-server/src/events/events.controller.ts
+++ b/api-server/src/events/events.controller.ts
@@ -42,7 +42,6 @@ import { VenueModel } from 'src/venues/models/venue.model';
 import { DatetimeVenueModel } from './models/datetime-venue.model';
 import { EventAdminMetadataModel } from './models/event-admin-metadata.model';
 import { PartnerModel } from '../users/models/partner.model';
-import isAdminUser from 'src/authentication/is-admin-user';
 import { validateAndExtractOptionalDateTimeFilters } from './utils/validateAndExtractOptionalDatetimeFilters';
 import { RequestWithUserInfo } from '../users/dto/RequestWithUserInfo';
 
@@ -156,8 +155,6 @@ export class EventsController {
     @Query('dateRange') dateRange?: string,
   ): Promise<EventsResponse> {
     const { page, pageSize } = pagination;
-
-    const isUserAdmin = request.userInformation?.isInfiniteAdmin || false;
 
     const [startDate, endDate] =
       validateAndExtractOptionalDateTimeFilters(dateRange);

--- a/api-server/src/events/events.controller.ts
+++ b/api-server/src/events/events.controller.ts
@@ -42,6 +42,7 @@ import { isNullOrUndefined } from '../utils';
 import { VenueModel } from 'src/venues/models/venue.model';
 import { DatetimeVenueModel } from './models/datetime-venue.model';
 import { EventAdminMetadataModel } from './models/event-admin-metadata.model';
+import { PartnerModel } from '../users/models/partner.model';
 import isAdminUser from 'src/authentication/is-admin-user';
 import { validateAndExtractOptionalDateTimeFilters } from './utils/validateAndExtractOptionalDatetimeFilters';
 
@@ -76,8 +77,8 @@ export class EventsController {
     const isAdmin = await isAdminUser(request);
 
     const include = isAdmin
-      ? [VenueModel, DatetimeVenueModel, EventAdminMetadataModel]
-      : [VenueModel, DatetimeVenueModel];
+      ? [VenueModel, DatetimeVenueModel, EventAdminMetadataModel, PartnerModel]
+      : [VenueModel, DatetimeVenueModel, PartnerModel];
 
     const findOptions = {
       include,

--- a/api-server/src/events/events.controller.ts
+++ b/api-server/src/events/events.controller.ts
@@ -1,7 +1,6 @@
 import moment from 'moment';
 import { Op, literal } from 'sequelize';
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,

--- a/api-server/src/events/events.controller.ts
+++ b/api-server/src/events/events.controller.ts
@@ -45,6 +45,7 @@ import { EventAdminMetadataModel } from './models/event-admin-metadata.model';
 import { PartnerModel } from '../users/models/partner.model';
 import isAdminUser from 'src/authentication/is-admin-user';
 import { validateAndExtractOptionalDateTimeFilters } from './utils/validateAndExtractOptionalDatetimeFilters';
+import { RequestWithUserInfo } from '../users/dto/RequestWithUserInfo';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
@@ -72,9 +73,9 @@ export class EventsController {
   async getAllCurrentVerified(
     @Query('tags') tags: string[] | string = [],
     @Query('category') category: string,
-    @Req() request: Request,
+    @Req() request: RequestWithUserInfo,
   ): Promise<EventsResponse> {
-    const isAdmin = await isAdminUser(request);
+    const isAdmin = request.userInformation?.isInfiniteAdmin || false;
 
     const include = isAdmin
       ? [VenueModel, DatetimeVenueModel, EventAdminMetadataModel, PartnerModel]
@@ -149,7 +150,7 @@ export class EventsController {
     description: 'Filter events by category',
   })
   async getAllVerified(
-    @Req() request: Request,
+    @Req() request: RequestWithUserInfo,
     @Query('tags') tags: string[] | string = [],
     @Query('category') category: string,
     @Query() pagination: PaginationDto,
@@ -157,7 +158,7 @@ export class EventsController {
   ): Promise<EventsResponse> {
     const { page, pageSize } = pagination;
 
-    const isUserAdmin = await isAdminUser(request);
+    const isUserAdmin = request.userInformation?.isInfiniteAdmin || false;
 
     const [startDate, endDate] =
       validateAndExtractOptionalDateTimeFilters(dateRange);
@@ -198,7 +199,7 @@ export class EventsController {
   getEventById(
     @Param() params: FindByIdParams,
     @Query('embed') embed: string[] | string = [],
-    @Req() request: Request,
+    @Req() request: RequestWithUserInfo,
   ): Promise<SingleEventResponse> {
     const id = params.id;
     const findOptions = {

--- a/api-server/src/events/events.controller.ts
+++ b/api-server/src/events/events.controller.ts
@@ -24,7 +24,6 @@ import SlackNotificationService, {
 } from '../notifications/slack-notification.service';
 import { EventsResponse } from './dto/events-response';
 import { SingleEventResponse } from './dto/single-event-response';
-import { Request } from 'express';
 import { removeSensitiveDataForNonAdmins } from '../authentication/filters/remove-sensitive-data-for-non-admins';
 import FindByIdParams from '../dto/find-by-id-params';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
@@ -172,7 +171,7 @@ export class EventsController {
         verifiedOnly: true,
         startDate,
         endDate,
-        isUserAdmin,
+        request,
       })
       .then((paginatedEventResp) => {
         const totalEntries = paginatedEventResp.count;

--- a/api-server/src/events/events.module.ts
+++ b/api-server/src/events/events.module.ts
@@ -9,6 +9,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { DatetimeVenueModel } from './models/datetime-venue.model';
 import { EventAdminMetadataModel } from './models/event-admin-metadata.model';
 import { VenueModel } from '../venues/models/venue.model';
+import { PartnerModel } from '../users/models/partner.model';
 import ExistingEventDetectionService from './existing-event-detection-service';
 import { ExistingEventDetectionController } from './existing-event-detection-controller';
 
@@ -19,6 +20,7 @@ import { ExistingEventDetectionController } from './existing-event-detection-con
       DatetimeVenueModel,
       EventAdminMetadataModel,
       VenueModel,
+      PartnerModel,
     ]),
     NotificationsModule,
   ],

--- a/api-server/src/events/events.module.ts
+++ b/api-server/src/events/events.module.ts
@@ -12,6 +12,8 @@ import { VenueModel } from '../venues/models/venue.model';
 import { PartnerModel } from '../users/models/partner.model';
 import ExistingEventDetectionService from './existing-event-detection-service';
 import { ExistingEventDetectionController } from './existing-event-detection-controller';
+import { UserModel } from '../users/users.modules';
+import UsersService from '../users/users.service';
 
 @Module({
   imports: [
@@ -21,6 +23,7 @@ import { ExistingEventDetectionController } from './existing-event-detection-con
       EventAdminMetadataModel,
       VenueModel,
       PartnerModel,
+      UserModel,
     ]),
     NotificationsModule,
   ],
@@ -29,6 +32,11 @@ import { ExistingEventDetectionController } from './existing-event-detection-con
     EventsAuthenticatedController,
     EventsController,
   ],
-  providers: [EventsService, BitlyService, ExistingEventDetectionService],
+  providers: [
+    EventsService,
+    BitlyService,
+    ExistingEventDetectionService,
+    UsersService,
+  ],
 })
 export class EventsModule {}

--- a/api-server/src/events/events.service.ts
+++ b/api-server/src/events/events.service.ts
@@ -107,7 +107,7 @@ export class EventsService {
         'Both startDate and endDate must be provided together',
       );
     }
-    return this.sequelize.transaction(async (_) => {
+    return this.sequelize.transaction(async () => {
       const tagClauseParams = this.getTagsClauseParams(tags);
       const whereClause = this.getWhereClause(
         tagClauseParams,

--- a/api-server/src/events/models/event.model.ts
+++ b/api-server/src/events/models/event.model.ts
@@ -1,4 +1,5 @@
 import {
+  BelongsTo,
   BelongsToMany,
   Column,
   DataType,
@@ -14,6 +15,7 @@ import { VenueModel } from '../../venues/models/venue.model';
 import { ApiProperty } from '@nestjs/swagger';
 import { DatetimeVenueModel } from './datetime-venue.model';
 import { EventAdminMetadataModel } from './event-admin-metadata.model';
+import { PartnerModel } from '../../users/models/partner.model';
 import { Optional, Utils } from 'sequelize';
 
 const EXAMPLE_DATE = new Date();
@@ -35,6 +37,11 @@ export class EventModel extends Model<EventModel> {
   @ApiProperty({ example: 'f467e7a0-a066-11ea-aa51-cdc3fe7afefa' })
   @ForeignKey(() => VenueModel)
   venue_id: string;
+
+  @Column
+  @ApiProperty({ example: 'f467e7a0-a066-11ea-aa51-cdc3fe7afefa', required: false })
+  @ForeignKey(() => PartnerModel)
+  owning_partner_id: string | null;
 
   @Column
   @ApiProperty({ example: 'Infinite Gallery Opening' })
@@ -141,4 +148,7 @@ export class EventModel extends Model<EventModel> {
 
   @HasOne(() => EventAdminMetadataModel)
   event_admin_metadata?: EventAdminMetadataModel;
+
+  @BelongsTo(() => PartnerModel)
+  owning_partner?: PartnerModel;
 }

--- a/api-server/src/events/models/event.model.ts
+++ b/api-server/src/events/models/event.model.ts
@@ -39,7 +39,10 @@ export class EventModel extends Model<EventModel> {
   venue_id: string;
 
   @Column
-  @ApiProperty({ example: 'f467e7a0-a066-11ea-aa51-cdc3fe7afefa', required: false })
+  @ApiProperty({
+    example: 'f467e7a0-a066-11ea-aa51-cdc3fe7afefa',
+    required: false,
+  })
   @ForeignKey(() => PartnerModel)
   owning_partner_id: string | null;
 

--- a/api-server/src/users/dto/RequestWithUserInfo.ts
+++ b/api-server/src/users/dto/RequestWithUserInfo.ts
@@ -2,7 +2,7 @@ import { Request } from 'express';
 import { UserInfoResp } from './user-info-resp';
 
 // This extends with built-in request interface with type information about
-// the current user. We affix this to the request via the suer-information-middleware
+// the current user. We affix this to the request via the user-information-middleware
 // so that when a user is authenticated this info will be available on all requests
 export interface RequestWithUserInfo extends Request {
   userInformation?: UserInfoResp;

--- a/api-server/src/users/dto/RequestWithUserInfo.ts
+++ b/api-server/src/users/dto/RequestWithUserInfo.ts
@@ -1,0 +1,6 @@
+import { Request } from 'express';
+import { UserInformation } from '../../authentication/parse-jwt';
+
+export interface RequestWithUserInfo extends Request {
+  userInformation: UserInformation;
+}

--- a/api-server/src/users/dto/RequestWithUserInfo.ts
+++ b/api-server/src/users/dto/RequestWithUserInfo.ts
@@ -1,6 +1,6 @@
 import { Request } from 'express';
-import { UserInformation } from '../../authentication/parse-jwt';
+import { UserInfoResp } from './user-info-resp';
 
 export interface RequestWithUserInfo extends Request {
-  userInformation: UserInformation;
+  userInformation: UserInfoResp;
 }

--- a/api-server/src/users/dto/RequestWithUserInfo.ts
+++ b/api-server/src/users/dto/RequestWithUserInfo.ts
@@ -1,6 +1,9 @@
 import { Request } from 'express';
 import { UserInfoResp } from './user-info-resp';
 
+// This extends with built-in request interface with type information about
+// the current user. We affix this to the request via the suer-information-middleware
+// so that when a user is authenticated this info will be available on all requests
 export interface RequestWithUserInfo extends Request {
-  userInformation: UserInfoResp;
+  userInformation?: UserInfoResp;
 }

--- a/api-server/src/users/dto/associate-user-partner-request.ts
+++ b/api-server/src/users/dto/associate-user-partner-request.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class AssociateUserPartnerRequest {
+  @ApiProperty({
+    description: 'UUID of the user to associate with the partner',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  user_id: string;
+
+  @ApiProperty({
+    description: 'UUID of the partner to associate with the user',
+    example: '987fcdeb-51a2-43d1-b456-426614174000',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  partner_id: string;
+}

--- a/api-server/src/users/dto/create-partner-request.ts
+++ b/api-server/src/users/dto/create-partner-request.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreatePartnerRequest {
+  @ApiProperty({
+    description: 'Name of the partner',
+    example: 'TechCorp Inc.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({
+    description: 'URL to the partner logo',
+    example: 'https://example.com/logo.png',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  logo_url?: string;
+}

--- a/api-server/src/users/dto/new-user.ts
+++ b/api-server/src/users/dto/new-user.ts
@@ -13,6 +13,10 @@ export default interface NewUser {
 export function buildFromUserInfo(userInfo: UserInformation): NewUser {
   const decodedTokenInfo = userInfo.decodedToken;
 
+  console.log(
+    '!!! decodedTokenInfo: ' + JSON.stringify(decodedTokenInfo, null, 4),
+  );
+
   return {
     name: decodedTokenInfo.name,
     nickname: decodedTokenInfo.nickname,

--- a/api-server/src/users/dto/new-user.ts
+++ b/api-server/src/users/dto/new-user.ts
@@ -13,10 +13,6 @@ export default interface NewUser {
 export function buildFromUserInfo(userInfo: UserInformation): NewUser {
   const decodedTokenInfo = userInfo.decodedToken;
 
-  console.log(
-    '!!! decodedTokenInfo: ' + JSON.stringify(decodedTokenInfo, null, 4),
-  );
-
   return {
     name: decodedTokenInfo.name,
     nickname: decodedTokenInfo.nickname,

--- a/api-server/src/users/dto/partner-dto.ts
+++ b/api-server/src/users/dto/partner-dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PartnerDTO {
+  @ApiProperty({
+    description: 'Unique identifier for the partner',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Name of the partner',
+    example: 'TechCorp Inc.',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: 'URL to the partner logo',
+    example: 'https://example.com/logo.png',
+    nullable: true,
+  })
+  logo_url: string | null;
+
+  @ApiProperty({
+    description: 'Timestamp when the partner was created',
+    example: '2024-01-15T10:30:00.000Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    description: 'Timestamp when the partner was last updated',
+    example: '2024-01-15T10:30:00.000Z',
+  })
+  updatedAt: Date;
+
+  constructor(partner: {
+    id: string;
+    name: string;
+    logo_url: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.id = partner.id;
+    this.name = partner.name;
+    this.logo_url = partner.logo_url;
+    this.createdAt = partner.createdAt;
+    this.updatedAt = partner.updatedAt;
+  }
+}

--- a/api-server/src/users/dto/partners-list-response.ts
+++ b/api-server/src/users/dto/partners-list-response.ts
@@ -1,0 +1,22 @@
+import { ResponseWrapper } from '../../dto/response-wrapper';
+import cloneAttributes from '../../utils/clone-attributes';
+import { PartnerDTO } from './partner-dto';
+
+export class PartnersListResponse extends ResponseWrapper {
+  partners: PartnerDTO[];
+
+  constructor(partners: PartnerDTO[]) {
+    super();
+
+    cloneAttributes<PartnersListResponse>(
+      {
+        partners,
+        paginated: false,
+        nextPage: null,
+        page: 0,
+        pageSize: partners.length,
+      },
+      this,
+    );
+  }
+}

--- a/api-server/src/users/dto/user-info-resp.ts
+++ b/api-server/src/users/dto/user-info-resp.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import isNotNullOrUndefined from '../../utils/is-not-null-or-undefined';
 import cloneAttributes from '../../utils/clone-attributes';
 import { v4 as uuidv4 } from 'uuid';
+import { PartnerDTO } from './partner-dto';
 
 const SAMPLE_GUID_1 = uuidv4();
 const SAMPLE_GUID_2 = uuidv4();
@@ -21,6 +22,21 @@ export class UserInfoResp {
 
   @ApiProperty({ example: [SAMPLE_GUID_2] })
   venueIDs?: string[];
+
+  @ApiProperty({ 
+    description: 'Partners associated with the user',
+    type: [PartnerDTO],
+    example: [
+      {
+        id: SAMPLE_GUID_2,
+        name: 'TechCorp Inc.',
+        logo_url: 'https://example.com/logo.png',
+        createdAt: '2024-01-15T10:30:00.000Z',
+        updatedAt: '2024-01-15T10:30:00.000Z'
+      }
+    ]
+  })
+  partners?: PartnerDTO[];
 
   constructor(copy?: UserInfoResp) {
     if (isNotNullOrUndefined(copy)) {

--- a/api-server/src/users/dto/user-info-resp.ts
+++ b/api-server/src/users/dto/user-info-resp.ts
@@ -21,7 +21,7 @@ export class UserInfoResp {
   isInfiniteAdmin: boolean;
 
   @ApiProperty({ example: false })
-  isOwnerAdmin: boolean;
+  isPartnerAdmin: boolean;
 
   @ApiProperty({ example: [SAMPLE_GUID_2] })
   venueIDs?: string[];

--- a/api-server/src/users/dto/user-info-resp.ts
+++ b/api-server/src/users/dto/user-info-resp.ts
@@ -20,10 +20,13 @@ export class UserInfoResp {
   @ApiProperty({ example: true })
   isInfiniteAdmin: boolean;
 
+  @ApiProperty({ example: false })
+  isOwnerAdmin: boolean;
+
   @ApiProperty({ example: [SAMPLE_GUID_2] })
   venueIDs?: string[];
 
-  @ApiProperty({ 
+  @ApiProperty({
     description: 'Partners associated with the user',
     type: [PartnerDTO],
     example: [
@@ -32,9 +35,9 @@ export class UserInfoResp {
         name: 'TechCorp Inc.',
         logo_url: 'https://example.com/logo.png',
         createdAt: '2024-01-15T10:30:00.000Z',
-        updatedAt: '2024-01-15T10:30:00.000Z'
-      }
-    ]
+        updatedAt: '2024-01-15T10:30:00.000Z',
+      },
+    ],
   })
   partners?: PartnerDTO[];
 

--- a/api-server/src/users/models/partner.model.ts
+++ b/api-server/src/users/models/partner.model.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  IsUUID,
+  Model,
+  PrimaryKey,
+  Table,
+  Unique,
+} from 'sequelize-typescript';
+import { ApiProperty } from '@nestjs/swagger';
+
+const SAMPLE_DATE = new Date();
+
+@Table({
+  tableName: 'partners',
+  indexes: [
+    {
+      unique: true,
+      fields: ['name'],
+      name: 'partners_name_lowercase_unique',
+    },
+  ],
+})
+export class PartnerModel extends Model<PartnerModel> {
+  @IsUUID(4)
+  @PrimaryKey
+  @Column
+  id: string;
+
+  @Column
+  @Unique
+  name: string;
+
+  @Column
+  logo_url: string;
+
+  @Column
+  @ApiProperty({ example: SAMPLE_DATE })
+  createdAt: Date;
+
+  @Column
+  @ApiProperty({ example: SAMPLE_DATE })
+  updatedAt: Date;
+}

--- a/api-server/src/users/models/partner.model.ts
+++ b/api-server/src/users/models/partner.model.ts
@@ -4,7 +4,6 @@ import {
   Model,
   PrimaryKey,
   Table,
-  Unique,
 } from 'sequelize-typescript';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -26,8 +25,7 @@ export class PartnerModel extends Model<PartnerModel> {
   @Column
   id: string;
 
-  @Column
-  @Unique
+  @Column({ unique: true })
   name: string;
 
   @Column

--- a/api-server/src/users/models/partner.model.ts
+++ b/api-server/src/users/models/partner.model.ts
@@ -1,6 +1,7 @@
 import {
   BelongsToMany,
   Column,
+  HasMany,
   IsUUID,
   Model,
   PrimaryKey,
@@ -8,6 +9,7 @@ import {
 } from 'sequelize-typescript';
 import { ApiProperty } from '@nestjs/swagger';
 import { UserModel } from './user.model';
+import { EventModel } from '../../events/models/event.model';
 
 const SAMPLE_DATE = new Date();
 
@@ -49,4 +51,11 @@ export class PartnerModel extends Model<PartnerModel> {
     as: 'users',
   })
   users: UserModel[];
+
+  // One-to-many association with events
+  @HasMany(() => EventModel, {
+    foreignKey: 'owning_partner_id',
+    as: 'events',
+  })
+  events: EventModel[];
 }

--- a/api-server/src/users/models/partner.model.ts
+++ b/api-server/src/users/models/partner.model.ts
@@ -1,4 +1,5 @@
 import {
+  BelongsToMany,
   Column,
   IsUUID,
   Model,
@@ -6,6 +7,7 @@ import {
   Table,
 } from 'sequelize-typescript';
 import { ApiProperty } from '@nestjs/swagger';
+import { UserModel } from './user.model';
 
 const SAMPLE_DATE = new Date();
 
@@ -38,4 +40,13 @@ export class PartnerModel extends Model<PartnerModel> {
   @Column
   @ApiProperty({ example: SAMPLE_DATE })
   updatedAt: Date;
+
+  // Many-to-many association with users
+  @BelongsToMany(() => UserModel, {
+    through: 'users_partners_mappings',
+    foreignKey: 'partner_id',
+    otherKey: 'user_id',
+    as: 'users',
+  })
+  users: UserModel[];
 }

--- a/api-server/src/users/models/user.model.ts
+++ b/api-server/src/users/models/user.model.ts
@@ -1,5 +1,5 @@
 import {
-   BelongsToMany,
+  BelongsToMany,
   Column,
   DataType,
   IsUUID,

--- a/api-server/src/users/models/user.model.ts
+++ b/api-server/src/users/models/user.model.ts
@@ -1,4 +1,5 @@
 import {
+   BelongsToMany,
   Column,
   DataType,
   IsUUID,
@@ -7,6 +8,7 @@ import {
   Table,
 } from 'sequelize-typescript';
 import { ApiProperty } from '@nestjs/swagger';
+import { PartnerModel } from './partner.model';
 
 const SAMPLE_DATE = new Date();
 
@@ -45,4 +47,13 @@ export class UserModel extends Model<UserModel> {
   @Column
   @ApiProperty({ example: SAMPLE_DATE })
   updatedAt: Date;
+
+  // Many-to-many association with partners
+  @BelongsToMany(() => PartnerModel, {
+    through: 'users_partners_mappings',
+    foreignKey: 'user_id',
+    otherKey: 'partner_id',
+    as: 'partners',
+  })
+  partners: PartnerModel[];
 }

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -1,12 +1,4 @@
-import {
-  Body,
-  Controller,
-  ForbiddenException,
-  Get,
-  Post,
-  Req,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { VERSION_1_URI } from '../utils/versionts';
 import {
   ApiBearerAuth,
@@ -15,15 +7,11 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AdminAuthGuard } from '../authentication/auth-guards/admin-auth.guard';
-import isAdminUser from '../authentication/is-admin-user';
 import { PartnersService } from './partners.service';
 import { CreatePartnerRequest } from './dto/create-partner-request';
 import { AssociateUserPartnerRequest } from './dto/associate-user-partner-request';
 import { PartnerDTO } from './dto/partner-dto';
 import { PartnersListResponse } from './dto/partners-list-response';
-import { Request } from 'express';
-
-const FORBIDDEN_ERROR_MESSAGE = 'User does not have admin privileges';
 
 @Controller(`${VERSION_1_URI}/authenticated/partners`)
 @UseGuards(AdminAuthGuard)
@@ -40,12 +28,7 @@ export class PartnersAuthenticatedController {
     description: 'List of all partners',
     type: PartnersListResponse,
   })
-  async getAll(@Req() request: Request): Promise<PartnersListResponse> {
-    const isAdmin = await isAdminUser(request);
-    if (!isAdmin) {
-      throw new ForbiddenException(FORBIDDEN_ERROR_MESSAGE);
-    }
-
+  async getAll(): Promise<PartnersListResponse> {
     const partners = await this.partnersService.findAll();
     return new PartnersListResponse(partners);
   }
@@ -67,13 +50,7 @@ export class PartnersAuthenticatedController {
   })
   async create(
     @Body() createPartnerRequest: CreatePartnerRequest,
-    @Req() request: Request,
   ): Promise<PartnerDTO> {
-    const isAdmin = await isAdminUser(request);
-    if (!isAdmin) {
-      throw new ForbiddenException(FORBIDDEN_ERROR_MESSAGE);
-    }
-
     const partner = await this.partnersService.create(createPartnerRequest);
     return new PartnerDTO(partner);
   }
@@ -98,13 +75,7 @@ export class PartnersAuthenticatedController {
   })
   async associateUserWithPartner(
     @Body() associateRequest: AssociateUserPartnerRequest,
-    @Req() request: Request,
   ): Promise<{ status: string; message: string }> {
-    const isAdmin = await isAdminUser(request);
-    if (!isAdmin) {
-      throw new ForbiddenException(FORBIDDEN_ERROR_MESSAGE);
-    }
-
     await this.partnersService.associateUserWithPartner(associateRequest);
 
     return {

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -14,7 +14,7 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { AuthGuard } from '../authentication/auth.guard';
+import { AdminAuthGuard } from '../authentication/AdminAuth.guard';
 import isAdminUser from '../authentication/is-admin-user';
 import { PartnersService } from './partners.service';
 import { CreatePartnerRequest } from './dto/create-partner-request';
@@ -25,7 +25,7 @@ import { Request } from 'express';
 const FORBIDDEN_ERROR_MESSAGE = 'User does not have admin privileges';
 
 @Controller(`${VERSION_1_URI}/authenticated/partners`)
-@UseGuards(AuthGuard)
+@UseGuards(AdminAuthGuard)
 @ApiTags('partners -- authenticated')
 @ApiBearerAuth()
 @ApiResponse({ status: 403, description: 'Forbidden' })
@@ -40,10 +40,8 @@ export class PartnersAuthenticatedController {
     type: PartnersListResponse,
   })
   async getAll(@Req() request: Request): Promise<PartnersListResponse> {
-    console.log('!!! try to get empty list');
     const isAdmin = await isAdminUser(request);
     if (!isAdmin) {
-      console.log('!!! FAILED');
       throw new ForbiddenException(FORBIDDEN_ERROR_MESSAGE);
     }
 

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -14,7 +14,7 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { AdminAuthGuard } from '../authentication/AdminAuth.guard';
+import { AdminAuthGuard } from '../authentication/auth-guards/admin-auth.guard';
 import isAdminUser from '../authentication/is-admin-user';
 import { PartnersService } from './partners.service';
 import { CreatePartnerRequest } from './dto/create-partner-request';

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { VERSION_1_URI } from '../utils/versionts';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AuthGuard } from '../authentication/auth.guard';
+import isAdminUser from '../authentication/is-admin-user';
+import { PartnersService } from './partners.service';
+import { CreatePartnerRequest } from './dto/create-partner-request';
+import { PartnerDTO } from './dto/partner-dto';
+import { PartnersListResponse } from './dto/partners-list-response';
+import { Request } from 'express';
+
+const FORBIDDEN_ERROR_MESSAGE = 'User does not have admin privileges';
+
+@Controller(`${VERSION_1_URI}/authenticated/partners`)
+@UseGuards(AuthGuard)
+@ApiTags('partners -- authenticated')
+@ApiBearerAuth()
+@ApiResponse({ status: 403, description: 'Forbidden' })
+export class PartnersAuthenticatedController {
+  constructor(private readonly partnersService: PartnersService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get all partners (admin only)' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of all partners',
+    type: PartnersListResponse,
+  })
+  async getAll(@Req() request: Request): Promise<PartnersListResponse> {
+    const isAdmin = await isAdminUser(request);
+    if (!isAdmin) {
+      throw new ForbiddenException(FORBIDDEN_ERROR_MESSAGE);
+    }
+
+    const partners = await this.partnersService.findAll();
+    return new PartnersListResponse(partners);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new partner (admin only)' })
+  @ApiResponse({
+    status: 201,
+    description: 'Partner created successfully',
+    type: PartnerDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - validation failed',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Conflict - partner with this name already exists',
+  })
+  async create(
+    @Body() createPartnerRequest: CreatePartnerRequest,
+    @Req() request: Request,
+  ): Promise<PartnerDTO> {
+    const isAdmin = await isAdminUser(request);
+    if (!isAdmin) {
+      throw new ForbiddenException(FORBIDDEN_ERROR_MESSAGE);
+    }
+
+    const partner = await this.partnersService.create(createPartnerRequest);
+    return new PartnerDTO(partner);
+  }
+}

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -99,15 +99,16 @@ export class PartnersAuthenticatedController {
   async associateUserWithPartner(
     @Body() associateRequest: AssociateUserPartnerRequest,
     @Req() request: Request,
-  ): Promise<{ message: string }> {
+  ): Promise<{ status: string; message: string }> {
     const isAdmin = await isAdminUser(request);
     if (!isAdmin) {
       throw new ForbiddenException(FORBIDDEN_ERROR_MESSAGE);
     }
 
     await this.partnersService.associateUserWithPartner(associateRequest);
-    
+
     return {
+      status: 'success',
       message: `User ${associateRequest.user_id} successfully associated with partner ${associateRequest.partner_id}`,
     };
   }

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -40,8 +40,10 @@ export class PartnersAuthenticatedController {
     type: PartnersListResponse,
   })
   async getAll(@Req() request: Request): Promise<PartnersListResponse> {
+    console.log('!!! try to get empty list');
     const isAdmin = await isAdminUser(request);
     if (!isAdmin) {
+      console.log('!!! FAILED');
       throw new ForbiddenException(FORBIDDEN_ERROR_MESSAGE);
     }
 

--- a/api-server/src/users/partners.controller.ts
+++ b/api-server/src/users/partners.controller.ts
@@ -9,7 +9,7 @@ import { PartnerDTO } from './dto/partner-dto';
 export class PartnersController {
   constructor(private readonly partnersService: PartnersService) {}
 
-  @Get(':name')
+  @Get('name/:name')
   @ApiOperation({
     summary: 'Get a partner by name',
     description:

--- a/api-server/src/users/partners.controller.ts
+++ b/api-server/src/users/partners.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+} from '@nestjs/common';
+import { VERSION_1_URI } from '../utils/versionts';
+import {
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { PartnersService } from './partners.service';
+import { PartnerDTO } from './dto/partner-dto';
+
+@Controller(`${VERSION_1_URI}/partners`)
+@ApiTags('partners')
+export class PartnersController {
+  constructor(private readonly partnersService: PartnersService) {}
+
+  @Get(':name')
+  @ApiOperation({ 
+    summary: 'Get a partner by name',
+    description: 'Retrieves a partner by their name. This endpoint is publicly accessible and does not require authentication.'
+  })
+  @ApiParam({
+    name: 'name',
+    description: 'The name of the partner to retrieve',
+    example: 'TechCorp Inc.',
+    type: String,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Partner found successfully',
+    type: PartnerDTO,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Partner not found',
+  })
+  async findByName(@Param('name') name: string): Promise<PartnerDTO> {
+    const partner = await this.partnersService.findByName(name);
+    
+    if (!partner) {
+      throw new NotFoundException(`Partner with name "${name}" not found`);
+    }
+
+    return new PartnerDTO(partner);
+  }
+}

--- a/api-server/src/users/partners.controller.ts
+++ b/api-server/src/users/partners.controller.ts
@@ -1,16 +1,6 @@
-import {
-  Controller,
-  Get,
-  NotFoundException,
-  Param,
-} from '@nestjs/common';
+import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
 import { VERSION_1_URI } from '../utils/versionts';
-import {
-  ApiOperation,
-  ApiParam,
-  ApiResponse,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PartnersService } from './partners.service';
 import { PartnerDTO } from './dto/partner-dto';
 
@@ -20,9 +10,10 @@ export class PartnersController {
   constructor(private readonly partnersService: PartnersService) {}
 
   @Get(':name')
-  @ApiOperation({ 
+  @ApiOperation({
     summary: 'Get a partner by name',
-    description: 'Retrieves a partner by their name. This endpoint is publicly accessible and does not require authentication.'
+    description:
+      'Retrieves a partner by their name. This endpoint is publicly accessible and does not require authentication.',
   })
   @ApiParam({
     name: 'name',
@@ -41,7 +32,7 @@ export class PartnersController {
   })
   async findByName(@Param('name') name: string): Promise<PartnerDTO> {
     const partner = await this.partnersService.findByName(name);
-    
+
     if (!partner) {
       throw new NotFoundException(`Partner with name "${name}" not found`);
     }

--- a/api-server/src/users/partners.service.ts
+++ b/api-server/src/users/partners.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/sequelize';
+import { PartnerModel } from './models/partner.model';
+import { CreatePartnerRequest } from './dto/create-partner-request';
+
+@Injectable()
+export class PartnersService {
+  constructor(
+    @InjectModel(PartnerModel) private partnersModel: typeof PartnerModel,
+  ) {}
+
+  async findAll(): Promise<PartnerModel[]> {
+    return this.partnersModel.findAll({
+      order: [['createdAt', 'ASC']],
+    });
+  }
+
+  async create(
+    createPartnerRequest: CreatePartnerRequest,
+  ): Promise<PartnerModel> {
+    return this.partnersModel.create({
+      name: createPartnerRequest.name,
+      logo_url: createPartnerRequest.logo_url || null,
+    });
+  }
+}

--- a/api-server/src/users/partners.service.ts
+++ b/api-server/src/users/partners.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { PartnerModel } from './models/partner.model';
 import { CreatePartnerRequest } from './dto/create-partner-request';
+import { v4 } from 'uuid';
 
 @Injectable()
 export class PartnersService {
@@ -19,6 +20,7 @@ export class PartnersService {
     createPartnerRequest: CreatePartnerRequest,
   ): Promise<PartnerModel> {
     return this.partnersModel.create({
+      id: v4(),
       name: createPartnerRequest.name,
       logo_url: createPartnerRequest.logo_url || null,
     });

--- a/api-server/src/users/partners.service.ts
+++ b/api-server/src/users/partners.service.ts
@@ -23,6 +23,12 @@ export class PartnersService {
     });
   }
 
+  async findByName(name: string): Promise<PartnerModel | null> {
+    return this.partnersModel.findOne({
+      where: { name },
+    });
+  }
+
   async create(
     createPartnerRequest: CreatePartnerRequest,
   ): Promise<PartnerModel> {

--- a/api-server/src/users/partners.service.ts
+++ b/api-server/src/users/partners.service.ts
@@ -1,13 +1,20 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { PartnerModel } from './models/partner.model';
+import { UserModel } from './models/user.model';
 import { CreatePartnerRequest } from './dto/create-partner-request';
+import { AssociateUserPartnerRequest } from './dto/associate-user-partner-request';
 import { v4 } from 'uuid';
 
 @Injectable()
 export class PartnersService {
   constructor(
     @InjectModel(PartnerModel) private partnersModel: typeof PartnerModel,
+    @InjectModel(UserModel) private usersModel: typeof UserModel,
   ) {}
 
   async findAll(): Promise<PartnerModel[]> {
@@ -33,5 +40,44 @@ export class PartnersService {
       // Re-throw other errors
       throw error;
     }
+  }
+
+  async associateUserWithPartner(
+    associateRequest: AssociateUserPartnerRequest,
+  ): Promise<void> {
+    const { user_id, partner_id } = associateRequest;
+
+    // Find the user with their current partners
+    const user = await this.usersModel.findByPk(user_id, {
+      include: [
+        {
+          model: PartnerModel,
+          as: 'partners',
+          through: { attributes: [] },
+        },
+      ],
+    });
+
+    if (!user) {
+      throw new NotFoundException(`User with ID ${user_id} not found`);
+    }
+
+    // Find the partner
+    const partner = await this.partnersModel.findByPk(partner_id);
+
+    if (!partner) {
+      throw new NotFoundException(`Partner with ID ${partner_id} not found`);
+    }
+
+    // Check if association already exists
+    const existingAssociation = user.partners.find((p) => p.id === partner_id);
+    if (existingAssociation) {
+      throw new ConflictException(
+        `User ${user_id} is already associated with partner ${partner_id}`,
+      );
+    }
+
+    // Create the association using Sequelize's association method
+    await (user as any).addPartner(partner);
   }
 }

--- a/api-server/src/users/users.controller.ts
+++ b/api-server/src/users/users.controller.ts
@@ -7,7 +7,6 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AuthenticatedUserGuard } from '../authentication/auth-guards/authenticated-user.guard';
-import UsersService from './users.service';
 import { UserInfoResp } from './dto/user-info-resp';
 import { PartnerDTO } from './dto/partner-dto';
 import { PartnersListResponse } from './dto/partners-list-response';
@@ -16,8 +15,6 @@ import { RequestWithUserInfo } from './dto/RequestWithUserInfo';
 @Controller(`${VERSION_1_URI}/users`)
 @ApiTags('users')
 export class UsersController {
-  constructor(private readonly userService: UsersService) {}
-
   @Get('current')
   @UseGuards(AuthenticatedUserGuard)
   @ApiBearerAuth()
@@ -30,7 +27,7 @@ export class UsersController {
   async getCurrentUser(
     @Req() request: RequestWithUserInfo,
   ): Promise<UserInfoResp> {
-    return await this.userService.ensureCurrentUserByName(request);
+    return request.userInformation;
   }
 
   @Get('current/partners')
@@ -53,13 +50,10 @@ export class UsersController {
   async getPartnersForUser(
     @Req() request: RequestWithUserInfo,
   ): Promise<PartnersListResponse> {
-    const persistedUserInfo = await this.userService.ensureCurrentUserByName(
-      request,
-    );
+    const userInfo = request.userInformation;
 
     return new PartnersListResponse(
-      persistedUserInfo.partners?.map((partner) => new PartnerDTO(partner)) ||
-        [],
+      userInfo.partners?.map((partner) => new PartnerDTO(partner)) || [],
     );
   }
 }

--- a/api-server/src/users/users.controller.ts
+++ b/api-server/src/users/users.controller.ts
@@ -7,10 +7,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AuthenticatedUserGuard } from '../authentication/authenticated-user.guard';
-import { Request } from 'express';
-import { UserInformation } from '../authentication/parse-jwt';
 import UsersService from './users.service';
-import { buildFromUserInfo } from './dto/new-user';
 import { UserInfoResp } from './dto/user-info-resp';
 import { PartnerDTO } from './dto/partner-dto';
 import { PartnersListResponse } from './dto/partners-list-response';

--- a/api-server/src/users/users.controller.ts
+++ b/api-server/src/users/users.controller.ts
@@ -12,6 +12,7 @@ import { UserInformation } from '../authentication/parse-jwt';
 import UsersService from './users.service';
 import { buildFromUserInfo } from './dto/new-user';
 import { UserInfoResp } from './dto/user-info-resp';
+import { PartnerDTO } from './dto/partner-dto';
 
 @Controller(`${VERSION_1_URI}/users`)
 @ApiTags('users')
@@ -30,11 +31,8 @@ export class UsersController {
   async getCurrentUser(
     @Req() request: RequestWithUserInfo,
   ): Promise<UserInfoResp> {
-    console.log('!!! much here');
     const userInfo: UserInformation = request.userInformation;
     const userInfoToPersist = buildFromUserInfo(userInfo);
-
-    console.log('!!! user info: ' + JSON.stringify(userInfo, null, 4));
 
     // TODO There's no real need to persist user info to db at this point, this was done when we were going to have
     // user curated lists and such
@@ -48,6 +46,7 @@ export class UsersController {
       nickname: userInfo.decodedToken.nickname,
       isInfiniteAdmin: userInfo.isInfiniteAdmin,
       venueIDs: userInfo.venueIds,
+      partners: persistedUserInfo.partners?.map(partner => new PartnerDTO(partner)) || [],
     });
   }
 }

--- a/api-server/src/users/users.controller.ts
+++ b/api-server/src/users/users.controller.ts
@@ -6,7 +6,7 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { AuthGuard } from '../authentication/auth.guard';
+import { AuthenticatedUserGuard } from '../authentication/authenticated-user.guard';
 import { Request } from 'express';
 import { UserInformation } from '../authentication/parse-jwt';
 import UsersService from './users.service';
@@ -19,7 +19,7 @@ export class UsersController {
   constructor(private readonly userService: UsersService) {}
 
   @Get('current')
-  @UseGuards(AuthGuard)
+  @UseGuards(AuthenticatedUserGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Return information about the authenticated user' })
   @ApiResponse({

--- a/api-server/src/users/users.controller.ts
+++ b/api-server/src/users/users.controller.ts
@@ -6,7 +6,7 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { AuthenticatedUserGuard } from '../authentication/authenticated-user.guard';
+import { AuthenticatedUserGuard } from '../authentication/auth-guards/authenticated-user.guard';
 import UsersService from './users.service';
 import { UserInfoResp } from './dto/user-info-resp';
 import { PartnerDTO } from './dto/partner-dto';

--- a/api-server/src/users/users.controller.ts
+++ b/api-server/src/users/users.controller.ts
@@ -30,8 +30,11 @@ export class UsersController {
   async getCurrentUser(
     @Req() request: RequestWithUserInfo,
   ): Promise<UserInfoResp> {
+    console.log('!!! much here');
     const userInfo: UserInformation = request.userInformation;
     const userInfoToPersist = buildFromUserInfo(userInfo);
+
+    console.log('!!! user info: ' + JSON.stringify(userInfo, null, 4));
 
     // TODO There's no real need to persist user info to db at this point, this was done when we were going to have
     // user curated lists and such

--- a/api-server/src/users/users.controller.ts
+++ b/api-server/src/users/users.controller.ts
@@ -14,6 +14,7 @@ import { buildFromUserInfo } from './dto/new-user';
 import { UserInfoResp } from './dto/user-info-resp';
 import { PartnerDTO } from './dto/partner-dto';
 import { PartnersListResponse } from './dto/partners-list-response';
+import { RequestWithUserInfo } from './dto/RequestWithUserInfo';
 
 @Controller(`${VERSION_1_URI}/users`)
 @ApiTags('users')
@@ -32,23 +33,7 @@ export class UsersController {
   async getCurrentUser(
     @Req() request: RequestWithUserInfo,
   ): Promise<UserInfoResp> {
-    const userInfo: UserInformation = request.userInformation;
-    const userInfoToPersist = buildFromUserInfo(userInfo);
-
-    const persistedUserInfo = await this.userService.ensureByName(
-      userInfoToPersist,
-    );
-
-    return new UserInfoResp({
-      id: persistedUserInfo.id,
-      name: userInfo.decodedToken.name,
-      nickname: userInfo.decodedToken.nickname,
-      isInfiniteAdmin: userInfo.isInfiniteAdmin,
-      venueIDs: userInfo.venueIds,
-      partners:
-        persistedUserInfo.partners?.map((partner) => new PartnerDTO(partner)) ||
-        [],
-    });
+    return await this.userService.ensureCurrentUserByName(request);
   }
 
   @Get('current/partners')
@@ -71,11 +56,8 @@ export class UsersController {
   async getPartnersForUser(
     @Req() request: RequestWithUserInfo,
   ): Promise<PartnersListResponse> {
-    const userInfo: UserInformation = request.userInformation;
-    const userInfoToPersist = buildFromUserInfo(userInfo);
-
-    const persistedUserInfo = await this.userService.ensureByName(
-      userInfoToPersist,
+    const persistedUserInfo = await this.userService.ensureCurrentUserByName(
+      request,
     );
 
     return new PartnersListResponse(
@@ -83,8 +65,4 @@ export class UsersController {
         [],
     );
   }
-}
-
-interface RequestWithUserInfo extends Request {
-  userInformation: UserInformation;
 }

--- a/api-server/src/users/users.modules.ts
+++ b/api-server/src/users/users.modules.ts
@@ -3,10 +3,16 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { UsersController } from './users.controller';
 import UsersService from './users.service';
 import { UserModel } from './models/user.model';
+import { PartnerModel } from './models/partner.model';
+import { PartnersService } from './partners.service';
+import { PartnersAuthenticatedController } from './partners.authenticated.controller';
 
 @Module({
-  imports: [SequelizeModule.forFeature([UserModel])],
-  controllers: [UsersController],
-  providers: [UsersService],
+  imports: [SequelizeModule.forFeature([UserModel, PartnerModel])],
+  controllers: [UsersController, PartnersAuthenticatedController],
+  providers: [UsersService, PartnersService],
 })
 export class UsersModules {}
+
+// Export models for use in other modules
+export { UserModel, PartnerModel };

--- a/api-server/src/users/users.modules.ts
+++ b/api-server/src/users/users.modules.ts
@@ -6,10 +6,11 @@ import { UserModel } from './models/user.model';
 import { PartnerModel } from './models/partner.model';
 import { PartnersService } from './partners.service';
 import { PartnersAuthenticatedController } from './partners.authenticated.controller';
+import { PartnersController } from './partners.controller';
 
 @Module({
   imports: [SequelizeModule.forFeature([UserModel, PartnerModel])],
-  controllers: [UsersController, PartnersAuthenticatedController],
+  controllers: [UsersController, PartnersAuthenticatedController, PartnersController],
   providers: [UsersService, PartnersService],
 })
 export class UsersModules {}

--- a/api-server/src/users/users.modules.ts
+++ b/api-server/src/users/users.modules.ts
@@ -10,8 +10,13 @@ import { PartnersController } from './partners.controller';
 
 @Module({
   imports: [SequelizeModule.forFeature([UserModel, PartnerModel])],
-  controllers: [UsersController, PartnersAuthenticatedController, PartnersController],
+  controllers: [
+    UsersController,
+    PartnersAuthenticatedController,
+    PartnersController,
+  ],
   providers: [UsersService, PartnersService],
+  exports: [UsersService, PartnersService],
 })
 export class UsersModules {}
 

--- a/api-server/src/users/users.service.ts
+++ b/api-server/src/users/users.service.ts
@@ -18,8 +18,8 @@ export default class UsersService {
     };
 
     return this.usersModel
-      .findOrCreate({ 
-        where: { name }, 
+      .findOrCreate({
+        where: { name },
         defaults: userToInsert,
         include: [
           {

--- a/api-server/src/users/users.service.ts
+++ b/api-server/src/users/users.service.ts
@@ -44,6 +44,7 @@ export default class UsersService {
     let userInfo: UserInformation;
     try {
       userInfo = await parseJwt(request);
+
       this.logger.debug('successfully parsed jwt');
     } catch (ex) {
       this.logger.error(ex);
@@ -54,7 +55,7 @@ export default class UsersService {
 
     const persistedUserInfo = await this.ensureByName(userInfoToPersist);
 
-    this.logger.log('userInofrmation set on request -- authenticated requests');
+    this.logger.log('userInformation set on request -- authenticated requests');
     return new UserInfoResp({
       id: persistedUserInfo.id,
       name: userInfo.decodedToken.name,

--- a/api-server/src/users/users.service.ts
+++ b/api-server/src/users/users.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { UserModel } from './models/user.model';
+import { PartnerModel } from './models/partner.model';
 import NewUser from './dto/new-user';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -17,7 +18,17 @@ export default class UsersService {
     };
 
     return this.usersModel
-      .findOrCreate({ where: { name }, defaults: userToInsert })
+      .findOrCreate({ 
+        where: { name }, 
+        defaults: userToInsert,
+        include: [
+          {
+            model: PartnerModel,
+            as: 'partners',
+            through: { attributes: [] }, // Exclude join table attributes
+          },
+        ],
+      })
       .then((resp) => resp[0]);
   }
 }

--- a/api-server/src/users/users.service.ts
+++ b/api-server/src/users/users.service.ts
@@ -5,7 +5,7 @@ import { PartnerModel } from './models/partner.model';
 import NewUser, { buildFromUserInfo } from './dto/new-user';
 import { v4 as uuidv4 } from 'uuid';
 import { RequestWithUserInfo } from './dto/RequestWithUserInfo';
-import { UserInformation } from '../authentication/parse-jwt';
+import { parseJwt, UserInformation } from '../authentication/parse-jwt';
 import { UserInfoResp } from './dto/user-info-resp';
 import { PartnerDTO } from './dto/partner-dto';
 import isNotNullOrUndefined from '../utils/is-not-null-or-undefined';
@@ -17,11 +17,21 @@ export default class UsersService {
   async ensureCurrentUserByName(
     request: RequestWithUserInfo,
   ): Promise<UserInfoResp> {
-    const userInfo: UserInformation = request.userInformation;
+    const userInfo: UserInformation = await parseJwt(request);
+
+    // issue is likely unserInfomration on request
+    console.log(
+      '!!! request: ' + JSON.stringify(request.userInformation, null, 4),
+    );
     const userInfoToPersist = buildFromUserInfo(userInfo);
 
     const persistedUserInfo = await this.ensureByName(userInfoToPersist);
 
+    console.log('!!! userInfo: ' + JSON.stringify(userInfo, null, 4));
+    console.log(
+      '!!! persisted Info: ' + JSON.stringify(persistedUserInfo, null, 4),
+    );
+    // !!! TODO ALSO MAKE SURE WE STRIP EMAILS OR MAYBE NOT MAKE SURE WE SHOW THEM
     return new UserInfoResp({
       id: persistedUserInfo.id,
       name: userInfo.decodedToken.name,

--- a/api-server/src/venues/venues.authenticated.controller.ts
+++ b/api-server/src/venues/venues.authenticated.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { VERSION_1_URI } from '../utils/versionts';
-import { AdminAuthGuard } from '../authentication/AdminAuth.guard';
+import { AdminAuthGuard } from '../authentication/auth-guards/admin-auth.guard';
 import {
   ApiBearerAuth,
   ApiOperation,

--- a/api-server/src/venues/venues.authenticated.controller.ts
+++ b/api-server/src/venues/venues.authenticated.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { VERSION_1_URI } from '../utils/versionts';
-import { AuthGuard } from '../authentication/auth.guard';
+import { AdminAuthGuard } from '../authentication/AdminAuth.guard';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -24,7 +24,7 @@ import isNullUndefinedOrEmpty from '../utils/isNullUndefinedOrEmpty';
 
 @Controller(`${VERSION_1_URI}/authenticated/venues`)
 @ApiTags('venues -- authenticated')
-@UseGuards(AuthGuard)
+@UseGuards(AdminAuthGuard)
 @ApiBearerAuth()
 @ApiResponse({ status: 403, description: 'Forbidden' })
 export default class VenuesAuthenticatedController {

--- a/api-server/src/venues/venues.module.ts
+++ b/api-server/src/venues/venues.module.ts
@@ -6,9 +6,10 @@ import { VenueModel } from './models/venue.model';
 import { NotificationsModule } from '../notifications/notifications.module';
 import VenuesAuthenticatedController from './venues.authenticated.controller';
 import { GpsService } from './gps.services';
+import { UsersModules } from '../users/users.modules';
 
 @Module({
-  imports: [SequelizeModule.forFeature([VenueModel]), NotificationsModule],
+  imports: [SequelizeModule.forFeature([VenueModel]), NotificationsModule, UsersModules],
   controllers: [VenuesController, VenuesAuthenticatedController],
   providers: [VenuesService, GpsService],
 })

--- a/api-server/src/venues/venues.module.ts
+++ b/api-server/src/venues/venues.module.ts
@@ -9,7 +9,11 @@ import { GpsService } from './gps.services';
 import { UsersModules } from '../users/users.modules';
 
 @Module({
-  imports: [SequelizeModule.forFeature([VenueModel]), NotificationsModule, UsersModules],
+  imports: [
+    SequelizeModule.forFeature([VenueModel]),
+    NotificationsModule,
+    UsersModules,
+  ],
   controllers: [VenuesController, VenuesAuthenticatedController],
   providers: [VenuesService, GpsService],
 })

--- a/api-server/test/current-events.e2e-spec.ts
+++ b/api-server/test/current-events.e2e-spec.ts
@@ -7,6 +7,7 @@ import { CURRENT_VERSION_URI } from '../src/utils/versionts';
 import { EventModel } from '../src/events/models/event.model';
 import generateEvent, { createEvent } from './fakers/event.faker';
 import generateVenue from './fakers/venue.faker';
+import faker from 'faker';
 import { ChildProcessWithoutNullStreams } from 'child_process';
 import runMigrations from './test-helpers/e2e-stack/run-migrations';
 import startApplication from './test-helpers/e2e-stack/start-application';
@@ -15,6 +16,7 @@ import killApp from './test-helpers/e2e-stack/kill-app';
 import stopDatabase from './test-helpers/e2e-stack/stop-database';
 import startDatabase from './test-helpers/e2e-stack/start-database';
 import { DatetimeVenueModel } from '../src/events/models/datetime-venue.model';
+import { PartnerModel } from '../src/users/models/partner.model';
 import { PORT } from '../src/constants';
 
 const today = new Date(Date.now());
@@ -28,6 +30,7 @@ let dbContainer: StartedTestContainer;
 let eventModel: typeof EventModel;
 let venueModel: typeof VenueModel;
 let datetimeVenueModel: typeof DatetimeVenueModel;
+let partnerModel: typeof PartnerModel;
 let testingModule: TestingModule;
 
 let dbHostPort: number;
@@ -50,6 +53,7 @@ describe('CurrentEvents (e2e)', () => {
     eventModel = databaseModels.eventModel;
     venueModel = databaseModels.venueModel;
     datetimeVenueModel = databaseModels.datetimeVenueModel;
+    partnerModel = databaseModels.partnerModel;
 
     testingModule = databaseModels.testingModule;
 
@@ -86,6 +90,8 @@ describe('CurrentEvents (e2e)', () => {
     if (eventModel) await deleteAllEvents();
 
     if (venueModel) await deleteAllVenues();
+
+    if (partnerModel) await deleteAllPartners();
 
     return Promise.resolve();
   });
@@ -308,6 +314,59 @@ describe('CurrentEvents (e2e)', () => {
           futureTime.end_time.toISOString(),
         );
       });
+  }); 
+
+  it('handles mixed events with and without partners in current-events', async () => {
+    const futureTime1 = getDateTimePair(getTimePlusX(today, 1));
+    const futureTime2 = getDateTimePair(getTimePlusX(today, 2));
+    const venue = await createVenue(generateVenue(venueModel));
+
+    // Create a partner
+    const partner = await partnerModel.create({
+      id: faker.datatype.uuid(),
+      name: 'Mixed Events Partner',
+      logo_url: 'https://example.com/mixed-events-logo.png',
+    });
+
+    // Create event with partner
+    const eventWithPartner = await createEvent(
+      generateEvent(eventModel, { 
+        venue_id: venue.id, 
+        verified: true,
+        owning_partner_id: partner.id,
+      }),
+      [futureTime1],
+    );
+
+    // Create event without partner
+    const eventWithoutPartner = await createEvent(
+      generateEvent(eventModel, { 
+        venue_id: venue.id, 
+        verified: true,
+      }),
+      [futureTime2],
+    );
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/events/current-verified`)
+      .expect(200)
+      .then(async (response) => {
+        expect(response.body.events.length).toEqual(2);
+
+        // Find events with and without partners
+        const eventWithPartnerData = response.body.events.find(e => e.owning_partner_id);
+        const eventWithoutPartnerData = response.body.events.find(e => !e.owning_partner_id);
+
+        // Verify event with partner has partner data
+        expect(eventWithPartnerData).toHaveProperty('owning_partner_id', partner.id);
+        expect(eventWithPartnerData).toHaveProperty('owning_partner');
+        expect(eventWithPartnerData.owning_partner).toHaveProperty('id', partner.id);
+        expect(eventWithPartnerData.owning_partner).toHaveProperty('name', partner.name);
+
+        // Verify event without partner has no partner data
+        expect(eventWithoutPartnerData).toHaveProperty('owning_partner_id', null);
+        expect(eventWithoutPartnerData.owning_partner).toBeUndefined();
+      });
   });
 
   function getTimePlusX(time, deltaHours) {
@@ -382,5 +441,9 @@ describe('CurrentEvents (e2e)', () => {
 
   async function deleteAllDatetimeVenues() {
     await datetimeVenueModel.destroy({ where: {} });
+  }
+
+  async function deleteAllPartners() {
+    await partnerModel.destroy({ where: {} });
   }
 });

--- a/api-server/test/current-events.e2e-spec.ts
+++ b/api-server/test/current-events.e2e-spec.ts
@@ -314,7 +314,7 @@ describe('CurrentEvents (e2e)', () => {
           futureTime.end_time.toISOString(),
         );
       });
-  }); 
+  });
 
   it('handles mixed events with and without partners in current-events', async () => {
     const futureTime1 = getDateTimePair(getTimePlusX(today, 1));
@@ -329,9 +329,9 @@ describe('CurrentEvents (e2e)', () => {
     });
 
     // Create event with partner
-    const eventWithPartner = await createEvent(
-      generateEvent(eventModel, { 
-        venue_id: venue.id, 
+    await createEvent(
+      generateEvent(eventModel, {
+        venue_id: venue.id,
         verified: true,
         owning_partner_id: partner.id,
       }),
@@ -339,9 +339,9 @@ describe('CurrentEvents (e2e)', () => {
     );
 
     // Create event without partner
-    const eventWithoutPartner = await createEvent(
-      generateEvent(eventModel, { 
-        venue_id: venue.id, 
+    await createEvent(
+      generateEvent(eventModel, {
+        venue_id: venue.id,
         verified: true,
       }),
       [futureTime2],
@@ -354,17 +354,33 @@ describe('CurrentEvents (e2e)', () => {
         expect(response.body.events.length).toEqual(2);
 
         // Find events with and without partners
-        const eventWithPartnerData = response.body.events.find(e => e.owning_partner_id);
-        const eventWithoutPartnerData = response.body.events.find(e => !e.owning_partner_id);
+        const eventWithPartnerData = response.body.events.find(
+          (e) => e.owning_partner_id,
+        );
+        const eventWithoutPartnerData = response.body.events.find(
+          (e) => !e.owning_partner_id,
+        );
 
         // Verify event with partner has partner data
-        expect(eventWithPartnerData).toHaveProperty('owning_partner_id', partner.id);
+        expect(eventWithPartnerData).toHaveProperty(
+          'owning_partner_id',
+          partner.id,
+        );
         expect(eventWithPartnerData).toHaveProperty('owning_partner');
-        expect(eventWithPartnerData.owning_partner).toHaveProperty('id', partner.id);
-        expect(eventWithPartnerData.owning_partner).toHaveProperty('name', partner.name);
+        expect(eventWithPartnerData.owning_partner).toHaveProperty(
+          'id',
+          partner.id,
+        );
+        expect(eventWithPartnerData.owning_partner).toHaveProperty(
+          'name',
+          partner.name,
+        );
 
         // Verify event without partner has no partner data
-        expect(eventWithoutPartnerData).toHaveProperty('owning_partner_id', null);
+        expect(eventWithoutPartnerData).toHaveProperty(
+          'owning_partner_id',
+          null,
+        );
         expect(eventWithoutPartnerData.owning_partner).toBeUndefined();
       });
   });

--- a/api-server/test/events.authenticated.e2e-spec.ts
+++ b/api-server/test/events.authenticated.e2e-spec.ts
@@ -772,6 +772,9 @@ describe('Authenticated Events API', () => {
             'logo_url',
             partner.logo_url,
           );
+          // Partner admins should see organizer_contact for their own events
+          expect(event).toHaveProperty('organizer_contact');
+          expect(event.organizer_contact).toBeDefined();
         });
 
         // Find events without partners
@@ -833,6 +836,9 @@ describe('Authenticated Events API', () => {
             'logo_url',
             partner.logo_url,
           );
+          // Partner admins should see organizer_contact for their own events
+          expect(event).toHaveProperty('organizer_contact');
+          expect(event.organizer_contact).toBeDefined();
         });
 
         // Find events without partners
@@ -890,6 +896,9 @@ describe('Authenticated Events API', () => {
         );
         expect(eventReturned.owning_partner).toHaveProperty('createdAt');
         expect(eventReturned.owning_partner).toHaveProperty('updatedAt');
+        // Partner admins should see organizer_contact for their own events
+        expect(eventReturned).toHaveProperty('organizer_contact');
+        expect(eventReturned.organizer_contact).toBeDefined();
       });
   });
 

--- a/api-server/test/events.authenticated.e2e-spec.ts
+++ b/api-server/test/events.authenticated.e2e-spec.ts
@@ -9,6 +9,7 @@ import {
 import { VenueModel } from '../src/venues/models/venue.model';
 import { DatetimeVenueModel } from '../src/events/models/datetime-venue.model';
 import { PartnerModel } from '../src/users/models/partner.model';
+import { UserModel } from '../src/users/models/user.model';
 import { TestingModule } from '@nestjs/testing';
 import startDatabase from './test-helpers/e2e-stack/start-database';
 import runMigrations from './test-helpers/e2e-stack/run-migrations';
@@ -35,6 +36,7 @@ describe('Authenticated Events API', () => {
   let venueModel: typeof VenueModel;
   let datetimeVenueModel: typeof DatetimeVenueModel;
   let partnerModel: typeof PartnerModel;
+  let userModel: typeof UserModel;
   let testingModule: TestingModule;
 
   let dbHostPort: number;
@@ -57,6 +59,7 @@ describe('Authenticated Events API', () => {
     venueModel = databaseModels.venueModel;
     datetimeVenueModel = databaseModels.datetimeVenueModel;
     partnerModel = databaseModels.partnerModel;
+    userModel = databaseModels.userModel;
 
     testingModule = databaseModels.testingModule;
 
@@ -732,19 +735,14 @@ describe('Authenticated Events API', () => {
     });
 
     // Create events with the partner
-    const [eventsWithPartner] = await createListOfFutureEventsInChronologicalOrder(
-      3,
-      {
+    const [eventsWithPartner] =
+      await createListOfFutureEventsInChronologicalOrder(3, {
         verified: true,
         owning_partner_id: partner.id,
-      },
-    );
+      });
 
     // Create events without partners
-    await createListOfFutureEventsInChronologicalOrder(
-      2,
-      { verified: true },
-    );
+    await createListOfFutureEventsInChronologicalOrder(2, { verified: true });
 
     const token = await login();
 
@@ -759,24 +757,31 @@ describe('Authenticated Events API', () => {
         expect(events.length).toBeGreaterThanOrEqual(3);
 
         // Find events with partners
-        const eventsWithPartners = events.filter(event => event.owning_partner_id);
+        const eventsWithPartners = events.filter(
+          (event) => event.owning_partner_id,
+        );
         expect(eventsWithPartners.length).toBeGreaterThanOrEqual(3);
 
         // Verify partner data is included
-        eventsWithPartners.forEach(event => {
+        eventsWithPartners.forEach((event) => {
           expect(event).toHaveProperty('owning_partner_id', partner.id);
           expect(event).toHaveProperty('owning_partner');
           expect(event.owning_partner).toHaveProperty('id', partner.id);
           expect(event.owning_partner).toHaveProperty('name', partner.name);
-          expect(event.owning_partner).toHaveProperty('logo_url', partner.logo_url);
+          expect(event.owning_partner).toHaveProperty(
+            'logo_url',
+            partner.logo_url,
+          );
         });
 
         // Find events without partners
-        const eventsWithoutPartners = events.filter(event => !event.owning_partner_id);
+        const eventsWithoutPartners = events.filter(
+          (event) => !event.owning_partner_id,
+        );
         expect(eventsWithoutPartners.length).toBeGreaterThanOrEqual(2);
 
         // Verify no partner data for events without partners
-        eventsWithoutPartners.forEach(event => {
+        eventsWithoutPartners.forEach((event) => {
           expect(event.owning_partner).toBeUndefined();
         });
       });
@@ -791,19 +796,14 @@ describe('Authenticated Events API', () => {
     });
 
     // Create non-verified events with the partner
-    const [eventsWithPartner] = await createListOfFutureEventsInChronologicalOrder(
-      2,
-      {
+    const [eventsWithPartner] =
+      await createListOfFutureEventsInChronologicalOrder(2, {
         verified: false,
         owning_partner_id: partner.id,
-      },
-    );
+      });
 
     // Create non-verified events without partners
-    await createListOfFutureEventsInChronologicalOrder(
-      1,
-      { verified: false },
-    );
+    await createListOfFutureEventsInChronologicalOrder(1, { verified: false });
 
     const token = await login();
 
@@ -818,24 +818,31 @@ describe('Authenticated Events API', () => {
         expect(events.length).toEqual(3);
 
         // Find events with partners
-        const eventsWithPartners = events.filter(event => event.owning_partner_id);
+        const eventsWithPartners = events.filter(
+          (event) => event.owning_partner_id,
+        );
         expect(eventsWithPartners.length).toEqual(2);
 
         // Verify partner data is included
-        eventsWithPartners.forEach(event => {
+        eventsWithPartners.forEach((event) => {
           expect(event).toHaveProperty('owning_partner_id', partner.id);
           expect(event).toHaveProperty('owning_partner');
           expect(event.owning_partner).toHaveProperty('id', partner.id);
           expect(event.owning_partner).toHaveProperty('name', partner.name);
-          expect(event.owning_partner).toHaveProperty('logo_url', partner.logo_url);
+          expect(event.owning_partner).toHaveProperty(
+            'logo_url',
+            partner.logo_url,
+          );
         });
 
         // Find events without partners
-        const eventsWithoutPartners = events.filter(event => !event.owning_partner_id);
+        const eventsWithoutPartners = events.filter(
+          (event) => !event.owning_partner_id,
+        );
         expect(eventsWithoutPartners.length).toEqual(1);
 
         // Verify no partner data for events without partners
-        eventsWithoutPartners.forEach(event => {
+        eventsWithoutPartners.forEach((event) => {
           expect(event.owning_partner).toBeUndefined();
         });
       });
@@ -873,8 +880,14 @@ describe('Authenticated Events API', () => {
         expect(eventReturned).toHaveProperty('owning_partner_id', partner.id);
         expect(eventReturned).toHaveProperty('owning_partner');
         expect(eventReturned.owning_partner).toHaveProperty('id', partner.id);
-        expect(eventReturned.owning_partner).toHaveProperty('name', partner.name);
-        expect(eventReturned.owning_partner).toHaveProperty('logo_url', partner.logo_url);
+        expect(eventReturned.owning_partner).toHaveProperty(
+          'name',
+          partner.name,
+        );
+        expect(eventReturned.owning_partner).toHaveProperty(
+          'logo_url',
+          partner.logo_url,
+        );
         expect(eventReturned.owning_partner).toHaveProperty('createdAt');
         expect(eventReturned.owning_partner).toHaveProperty('updatedAt');
       });
@@ -902,6 +915,284 @@ describe('Authenticated Events API', () => {
         expect(eventReturned).toHaveProperty('owning_partner_id', null);
         expect(eventReturned.owning_partner).toBeUndefined();
       });
+  });
+
+  describe('GET /authenticated/events/non-verified-for-partners', () => {
+    it('should return 403 when user is not authenticated', async () => {
+      await createListOfFutureEventsInChronologicalOrder(3);
+
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events/non-verified-for-partners`,
+        )
+        .expect(403);
+    });
+
+    it("should return only non-verified events from user's associated partners", async () => {
+      // Create partners
+      const userPartner1 = await createPartner({
+        name: 'User Partner 1',
+        logo_url: 'https://example.com/user-partner-1.png',
+      });
+
+      const userPartner2 = await createPartner({
+        name: 'User Partner 2',
+        logo_url: 'https://example.com/user-partner-2.png',
+      });
+
+      const otherPartner = await createPartner({
+        name: 'Other Partner',
+        logo_url: 'https://example.com/other-partner.png',
+      });
+
+      // Create a user with JWT token
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      // Create the user in the database
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200);
+
+      const userId = userResponse.body.id;
+
+      // Associate user with their partners
+      await associateUserWithPartners(userId, [
+        userPartner1.id,
+        userPartner2.id,
+      ]);
+
+      // Create non-verified events for user's partners (should be included)
+      const userPartner1Event = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: false,
+          owning_partner_id: userPartner1.id,
+        },
+      );
+
+      const userPartner2Event = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: false,
+          owning_partner_id: userPartner2.id,
+        },
+      );
+
+      // Create non-verified event for other partner (should be excluded)
+      const otherPartnerEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: false,
+          owning_partner_id: otherPartner.id,
+        },
+      );
+
+      // Create non-verified event without partner (should be excluded)
+      const noPartnerEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: false,
+        },
+      );
+
+      // Create verified event for user's partner (should be excluded)
+      const verifiedUserPartnerEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: true,
+          owning_partner_id: userPartner1.id,
+        },
+      );
+
+      // Call the endpoint
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events/non-verified-for-partners`,
+        )
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(async ({ body }) => {
+          const { status, events } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(2);
+
+          // Verify only events from user's partners are returned
+          const eventIds = events.map((event: any) => event.id);
+          expect(eventIds).toContain(userPartner1Event.id);
+          expect(eventIds).toContain(userPartner2Event.id);
+
+          // Verify excluded events are not returned
+          expect(eventIds).not.toContain(otherPartnerEvent.id);
+          expect(eventIds).not.toContain(noPartnerEvent.id);
+          expect(eventIds).not.toContain(verifiedUserPartnerEvent.id);
+
+          // Verify event structure includes partner information
+          const userPartner1EventReturned = events.find(
+            (e: any) => e.id === userPartner1Event.id,
+          );
+          expect(userPartner1EventReturned).toHaveProperty(
+            'owning_partner_id',
+            userPartner1.id,
+          );
+          expect(userPartner1EventReturned).toHaveProperty('owning_partner');
+          expect(userPartner1EventReturned.owning_partner).toHaveProperty(
+            'id',
+            userPartner1.id,
+          );
+          expect(userPartner1EventReturned.owning_partner).toHaveProperty(
+            'name',
+            userPartner1.name,
+          );
+
+          const userPartner2EventReturned = events.find(
+            (e: any) => e.id === userPartner2Event.id,
+          );
+          expect(userPartner2EventReturned).toHaveProperty(
+            'owning_partner_id',
+            userPartner2.id,
+          );
+          expect(userPartner2EventReturned).toHaveProperty('owning_partner');
+          expect(userPartner2EventReturned.owning_partner).toHaveProperty(
+            'id',
+            userPartner2.id,
+          );
+          expect(userPartner2EventReturned.owning_partner).toHaveProperty(
+            'name',
+            userPartner2.name,
+          );
+        });
+    });
+
+    it('should return empty list when user has no non-verified events from their partners', async () => {
+      // Create a partner
+      const userPartner = await createPartner({
+        name: 'User Partner',
+        logo_url: 'https://example.com/user-partner.png',
+      });
+
+      // Create a user with JWT token
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      // Create the user in the database
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200);
+
+      const userId = userResponse.body.id;
+
+      // Associate user with partner
+      await associateUserWithPartners(userId, [userPartner.id]);
+
+      // Create only verified events for user's partner
+      await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: true,
+          owning_partner_id: userPartner.id,
+        },
+      );
+
+      // Call the endpoint
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events/non-verified-for-partners`,
+        )
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(({ body }) => {
+          const { status, events } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(0);
+        });
+    });
+
+    it('should work for infinite admin and return all non-verified events', async () => {
+      // Create partners
+      const partner1 = await createPartner({
+        name: 'Partner 1',
+        logo_url: 'https://example.com/partner-1.png',
+      });
+
+      const partner2 = await createPartner({
+        name: 'Partner 2',
+        logo_url: 'https://example.com/partner-2.png',
+      });
+
+      // Create infinite admin user
+      const adminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': true,
+      });
+
+      // Create non-verified events for different partners
+      const partner1Event = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: false,
+          owning_partner_id: partner1.id,
+        },
+      );
+
+      const partner2Event = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: false,
+          owning_partner_id: partner2.id,
+        },
+      );
+
+      const noPartnerEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: false,
+        },
+      );
+
+      // Call the endpoint
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events/non-verified-for-partners`,
+        )
+        .set({ 'x-access-token': adminToken })
+        .expect(200)
+        .then(({ body }) => {
+          const { status, events } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(3);
+
+          // Verify all non-verified events are returned
+          const eventIds = events.map((event: any) => event.id);
+          expect(eventIds).toContain(partner1Event.id);
+          expect(eventIds).toContain(partner2Event.id);
+          expect(eventIds).toContain(noPartnerEvent.id);
+        });
+    });
   });
 
   describe('Non-Admin Access Tests', () => {
@@ -995,7 +1286,9 @@ describe('Authenticated Events API', () => {
       };
 
       return server
-        .put(`/${CURRENT_VERSION_URI}/authenticated/events/${eventId}/admin-metadata`)
+        .put(
+          `/${CURRENT_VERSION_URI}/authenticated/events/${eventId}/admin-metadata`,
+        )
         .set('x-access-token', nonAdminToken)
         .send(adminMetadata)
         .expect(403);
@@ -1005,7 +1298,9 @@ describe('Authenticated Events API', () => {
       await createListOfFutureEventsInChronologicalOrder(5);
 
       return server
-        .get(`/${CURRENT_VERSION_URI}/authenticated/events?page=1&pageSize=10&tags=music&category=concert`)
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events?page=1&pageSize=10&tags=music&category=concert`,
+        )
         .set('x-access-token', nonAdminToken)
         .expect(403);
     });
@@ -1014,7 +1309,9 @@ describe('Authenticated Events API', () => {
       await createListOfFutureEventsInChronologicalOrder(3);
 
       return server
-        .get(`/${CURRENT_VERSION_URI}/authenticated/events?dateRange=2024-01-01T00:00:00.000Z/2024-12-31T23:59:59.999Z`)
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events?dateRange=2024-01-01T00:00:00.000Z/2024-12-31T23:59:59.999Z`,
+        )
         .set('x-access-token', nonAdminToken)
         .expect(403);
     });
@@ -1046,5 +1343,26 @@ describe('Authenticated Events API', () => {
       .then(({ body }) => {
         return body.token;
       });
+  }
+
+  async function createPartner(partnerData: any): Promise<PartnerModel> {
+    return partnerModel.create({
+      ...partnerData,
+      id: uuidv4(),
+    });
+  }
+
+  async function associateUserWithPartners(
+    userId: string,
+    partnerIds: string[],
+  ): Promise<void> {
+    // Use Sequelize's association methods to create the many-to-many relationship
+    const user = await userModel.findByPk(userId);
+    const partners = await partnerModel.findAll({
+      where: { id: partnerIds },
+    });
+
+    // Use the association method to set partners
+    await (user as any).setPartners(partners);
   }
 });

--- a/api-server/test/events.authenticated.e2e-spec.ts
+++ b/api-server/test/events.authenticated.e2e-spec.ts
@@ -735,11 +735,10 @@ describe('Authenticated Events API', () => {
     });
 
     // Create events with the partner
-    const [eventsWithPartner] =
-      await createListOfFutureEventsInChronologicalOrder(3, {
-        verified: true,
-        owning_partner_id: partner.id,
-      });
+    await createListOfFutureEventsInChronologicalOrder(3, {
+      verified: true,
+      owning_partner_id: partner.id,
+    });
 
     // Create events without partners
     await createListOfFutureEventsInChronologicalOrder(2, { verified: true });
@@ -799,11 +798,10 @@ describe('Authenticated Events API', () => {
     });
 
     // Create non-verified events with the partner
-    const [eventsWithPartner] =
-      await createListOfFutureEventsInChronologicalOrder(2, {
-        verified: false,
-        owning_partner_id: partner.id,
-      });
+    await createListOfFutureEventsInChronologicalOrder(2, {
+      verified: false,
+      owning_partner_id: partner.id,
+    });
 
     // Create non-verified events without partners
     await createListOfFutureEventsInChronologicalOrder(1, { verified: false });

--- a/api-server/test/events.e2e-spec.ts
+++ b/api-server/test/events.e2e-spec.ts
@@ -1073,11 +1073,10 @@ describe('Events API', () => {
     });
 
     // Create events with the partner
-    const [eventsWithPartner] =
-      await createListOfFutureEventsInChronologicalOrder(3, {
-        verified: true,
-        owning_partner_id: partner.id,
-      });
+    await createListOfFutureEventsInChronologicalOrder(3, {
+      verified: true,
+      owning_partner_id: partner.id,
+    });
 
     // Create events without partners
     await createListOfFutureEventsInChronologicalOrder(2, { verified: true });
@@ -1351,13 +1350,6 @@ describe('Events API', () => {
         });
     });
   });
-
-  async function createPartner(partnerData: any): Promise<PartnerModel> {
-    return partnerModel.create({
-      ...partnerData,
-      id: uuidv4(),
-    });
-  }
 
   async function associateUserWithPartners(
     userId: string,

--- a/api-server/test/events.e2e-spec.ts
+++ b/api-server/test/events.e2e-spec.ts
@@ -1009,7 +1009,7 @@ describe('Events API', () => {
       eventModel,
       venueModel,
       datetimeVenueModel,
-      { 
+      {
         verified: true,
         owning_partner_id: partner.id,
       },
@@ -1020,13 +1020,19 @@ describe('Events API', () => {
       .expect(200)
       .then(async ({ body }) => {
         const { event: eventReturned, status } = body;
-        
+
         expect(status).toEqual('success');
         expect(eventReturned).toHaveProperty('owning_partner_id', partner.id);
         expect(eventReturned).toHaveProperty('owning_partner');
         expect(eventReturned.owning_partner).toHaveProperty('id', partner.id);
-        expect(eventReturned.owning_partner).toHaveProperty('name', partner.name);
-        expect(eventReturned.owning_partner).toHaveProperty('logo_url', partner.logo_url);
+        expect(eventReturned.owning_partner).toHaveProperty(
+          'name',
+          partner.name,
+        );
+        expect(eventReturned.owning_partner).toHaveProperty(
+          'logo_url',
+          partner.logo_url,
+        );
         expect(eventReturned.owning_partner).toHaveProperty('createdAt');
         expect(eventReturned.owning_partner).toHaveProperty('updatedAt');
       });
@@ -1046,7 +1052,7 @@ describe('Events API', () => {
       .expect(200)
       .then(async ({ body }) => {
         const { event: eventReturned, status } = body;
-        
+
         expect(status).toEqual('success');
         expect(eventReturned).toHaveProperty('owning_partner_id', null);
         expect(eventReturned.owning_partner).toBeUndefined();
@@ -1062,48 +1068,50 @@ describe('Events API', () => {
     });
 
     // Create events with the partner
-    const [eventsWithPartner] = await createListOfFutureEventsInChronologicalOrder(
-      3,
-      { 
+    const [eventsWithPartner] =
+      await createListOfFutureEventsInChronologicalOrder(3, {
         verified: true,
         owning_partner_id: partner.id,
-      },
-    );
+      });
 
     // Create events without partners
-    await createListOfFutureEventsInChronologicalOrder(
-      2,
-      { verified: true },
-    );
+    await createListOfFutureEventsInChronologicalOrder(2, { verified: true });
 
     return server
       .get(`/${CURRENT_VERSION_URI}/events/verified?page=1&pageSize=10`)
       .expect(200)
       .then(async ({ body }) => {
         const { events, status } = body;
-        
+
         expect(status).toEqual('success');
         expect(events.length).toBeGreaterThanOrEqual(3);
 
         // Find events with partners
-        const eventsWithPartners = events.filter(event => event.owning_partner_id);
+        const eventsWithPartners = events.filter(
+          (event) => event.owning_partner_id,
+        );
         expect(eventsWithPartners.length).toBeGreaterThanOrEqual(3);
 
         // Verify partner data is included
-        eventsWithPartners.forEach(event => {
+        eventsWithPartners.forEach((event) => {
           expect(event).toHaveProperty('owning_partner_id', partner.id);
           expect(event).toHaveProperty('owning_partner');
           expect(event.owning_partner).toHaveProperty('id', partner.id);
           expect(event.owning_partner).toHaveProperty('name', partner.name);
-          expect(event.owning_partner).toHaveProperty('logo_url', partner.logo_url);
+          expect(event.owning_partner).toHaveProperty(
+            'logo_url',
+            partner.logo_url,
+          );
         });
 
         // Find events without partners
-        const eventsWithoutPartners = events.filter(event => !event.owning_partner_id);
+        const eventsWithoutPartners = events.filter(
+          (event) => !event.owning_partner_id,
+        );
         expect(eventsWithoutPartners.length).toBeGreaterThanOrEqual(2);
 
         // Verify no partner data for events without partners
-        eventsWithoutPartners.forEach(event => {
+        eventsWithoutPartners.forEach((event) => {
           expect(event.owning_partner).toBeUndefined();
         });
       });

--- a/api-server/test/fakers/partner.faker.ts
+++ b/api-server/test/fakers/partner.faker.ts
@@ -1,0 +1,13 @@
+import { CreatePartnerRequest } from '../../src/users/dto/create-partner-request';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const faker = require('faker');
+
+function generatePartnerRequest(): CreatePartnerRequest {
+  return {
+    name: faker.company.companyName(),
+    logo_url: faker.internet.url() + '/logo.png',
+  };
+}
+
+export default generatePartnerRequest;

--- a/api-server/test/partners.authenticated.e2e-spec.ts
+++ b/api-server/test/partners.authenticated.e2e-spec.ts
@@ -1,0 +1,253 @@
+import startDatabase from './test-helpers/e2e-stack/start-database';
+import runMigrations from './test-helpers/e2e-stack/run-migrations';
+import startApplication from './test-helpers/e2e-stack/start-application';
+import buildDbConnectionsForTests from './test-helpers/e2e-stack/build-db-connection-for-tests';
+import request from 'supertest';
+import { ChildProcessWithoutNullStreams } from 'child_process';
+import { StartedTestContainer } from 'testcontainers';
+import { TestingModule } from '@nestjs/testing';
+import { PartnerModel } from '../src/users/models/partner.model';
+import killApp from './test-helpers/e2e-stack/kill-app';
+import stopDatabase from './test-helpers/e2e-stack/stop-database';
+import isNotNullOrUndefined from '../src/utils/is-not-null-or-undefined';
+import { CreatePartnerRequest } from '../src/users/dto/create-partner-request';
+import generatePartnerRequest from './fakers/partner.faker';
+import { CURRENT_VERSION_URI } from '../src/utils/versionts';
+import { v4 as uuidv4 } from 'uuid';
+import { PORT } from '../src/constants';
+import createJwtForRandomUser from './test-helpers/creaeteJwt';
+
+const server = request('http://localhost:' + PORT);
+
+let appUnderTest: ChildProcessWithoutNullStreams;
+let dbContainer: StartedTestContainer;
+
+let partnerModel: typeof PartnerModel;
+let testingModule: TestingModule;
+
+let dbHostPort: number;
+
+describe('Partners Authenticated (e2e)', () => {
+  beforeAll(async () => {
+    console.info('preparing for test suite -- Partners Authenticated');
+
+    const dbInfo = await startDatabase();
+
+    dbContainer = dbInfo.dbContainer;
+    dbHostPort = dbInfo.dbHostPort;
+
+    await runMigrations(dbHostPort);
+
+    appUnderTest = await startApplication(dbHostPort);
+
+    const databaseModels = await buildDbConnectionsForTests(dbHostPort);
+
+    partnerModel = databaseModels.partnerModel;
+    testingModule = databaseModels.testingModule;
+
+    console.info('test suite ready');
+
+    return Promise.resolve();
+  }, 30000);
+
+  afterAll(async () => {
+    console.info('begin cleanup for partners authenticated');
+
+    await killApp(appUnderTest);
+
+    if (appUnderTest) {
+      appUnderTest.removeAllListeners();
+    }
+
+    await stopDatabase(dbContainer);
+
+    if (isNotNullOrUndefined(testingModule)) await testingModule.close();
+
+    console.info('done cleaning up for partners authenticated');
+    return Promise.resolve();
+  });
+
+  beforeEach(async () => {
+    await deleteAllPartners();
+  });
+
+  describe('GET /authenticated/partners', () => {
+    it('should return 403 when user is not authenticated', async () => {
+      return server
+        .get(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .expect(403);
+    });
+
+    it('should return 403 when user is authenticated but not admin', async () => {
+      const nonAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      return server
+        .get(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .set({ 'x-access-token': nonAdminToken })
+        .expect(403);
+    });
+
+    it('should return empty list when no partners exist', async () => {
+      const adminToken = await createJwtForRandomUser();
+
+      return server
+        .get(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .set({ 'x-access-token': adminToken })
+        .expect(200)
+        .then((response) => {
+          expect(response.body.status).toEqual('success');
+          expect(response.body.paginated).toEqual(false);
+          expect(response.body.page).toEqual(0);
+          expect(response.body.pageSize).toEqual(0);
+          expect(response.body.nextPage).toEqual(null);
+          expect(response.body.partners).toEqual([]);
+        });
+    });
+
+    it('should return all partners when partners exist', async () => {
+      const partner1 = await createPartner(generatePartnerRequest());
+      const partner2 = await createPartner(generatePartnerRequest());
+
+      const adminToken = await createJwtForRandomUser();
+
+      return server
+        .get(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .set({ 'x-access-token': adminToken })
+        .expect(200)
+        .then((response) => {
+          expect(response.body.status).toEqual('success');
+          expect(response.body.paginated).toEqual(false);
+          expect(response.body.page).toEqual(0);
+          expect(response.body.pageSize).toEqual(2);
+          expect(response.body.nextPage).toEqual(null);
+          expect(response.body.partners).toHaveLength(2);
+
+          // Check that partners are ordered by createdAt ASC
+          const partners = response.body.partners;
+          expect(partners[0].id).toEqual(partner1.id);
+          expect(partners[1].id).toEqual(partner2.id);
+          expect(partners[0].name).toEqual(partner1.name);
+          expect(partners[1].name).toEqual(partner2.name);
+        });
+    });
+  });
+
+  describe('POST /authenticated/partners', () => {
+    it('should return 403 when user is not authenticated', async () => {
+      const partnerRequest = generatePartnerRequest();
+
+      return server
+        .post(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .send(partnerRequest)
+        .expect(403);
+    });
+
+    it('should return 403 when user is authenticated but not admin', async () => {
+      const nonAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+      const partnerRequest = generatePartnerRequest();
+
+      return server
+        .post(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .set({ 'x-access-token': nonAdminToken })
+        .send(partnerRequest)
+        .expect(403);
+    });
+
+    it('should create a new partner with name and logo_url', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const partnerRequest = generatePartnerRequest();
+
+      return server
+        .post(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .set({ 'x-access-token': adminToken })
+        .send(partnerRequest)
+        .expect(201)
+        .then((response) => {
+          expect(response.body.id).toBeDefined();
+          expect(response.body.name).toEqual(partnerRequest.name);
+          expect(response.body.logo_url).toEqual(partnerRequest.logo_url);
+          expect(response.body.createdAt).toBeDefined();
+          expect(response.body.updatedAt).toBeDefined();
+        });
+    });
+
+    it('should create a new partner with only name (logo_url optional)', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const partnerRequest: CreatePartnerRequest = {
+        name: 'Test Partner',
+      };
+
+      return server
+        .post(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .set({ 'x-access-token': adminToken })
+        .send(partnerRequest)
+        .expect(201)
+        .then((response) => {
+          expect(response.body.id).toBeDefined();
+          expect(response.body.name).toEqual(partnerRequest.name);
+          expect(response.body.logo_url).toEqual(null);
+          expect(response.body.createdAt).toBeDefined();
+          expect(response.body.updatedAt).toBeDefined();
+        });
+    });
+
+    it('should return 400 when name is missing', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const partnerRequest = {
+        logo_url: 'https://example.com/logo.png',
+      };
+
+      return server
+        .post(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .set({ 'x-access-token': adminToken })
+        .send(partnerRequest)
+        .expect(400);
+    });
+
+    it('should return 400 when name is empty', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const partnerRequest = {
+        name: '',
+        logo_url: 'https://example.com/logo.png',
+      };
+
+      return server
+        .post(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .set({ 'x-access-token': adminToken })
+        .send(partnerRequest)
+        .expect(400);
+    });
+
+    it('should return 409 when partner name already exists (case-insensitive)', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const partnerRequest = generatePartnerRequest();
+
+      // Create first partner
+      await createPartner(partnerRequest);
+
+      // Try to create partner with same name but different case
+      const duplicateRequest = {
+        ...partnerRequest,
+        name: partnerRequest.name.toUpperCase(),
+      };
+
+      return server
+        .post(`/${CURRENT_VERSION_URI}/authenticated/partners`)
+        .set({ 'x-access-token': adminToken })
+        .send(duplicateRequest)
+        .expect(409);
+    });
+  });
+
+  function createPartner(partner: CreatePartnerRequest): Promise<PartnerModel> {
+    return partnerModel.create({ ...partner, id: uuidv4() });
+  }
+
+  function deleteAllPartners(): Promise<number> {
+    return partnerModel.destroy({ where: {} });
+  }
+});

--- a/api-server/test/partners.e2e-spec.ts
+++ b/api-server/test/partners.e2e-spec.ts
@@ -66,7 +66,9 @@ describe('Partners API (e2e)', () => {
     });
 
     return server
-      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`)
+      .get(
+        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`,
+      )
       .expect(200)
       .then(async ({ body }) => {
         expect(body).toHaveProperty('id', partner.id);
@@ -81,10 +83,16 @@ describe('Partners API (e2e)', () => {
     const nonExistentName = 'Non Existent Partner';
 
     return server
-      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(nonExistentName)}`)
+      .get(
+        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(
+          nonExistentName,
+        )}`,
+      )
       .expect(404)
       .then(async ({ body }) => {
-        expect(body.message).toContain(`Partner with name "${nonExistentName}" not found`);
+        expect(body.message).toContain(
+          `Partner with name "${nonExistentName}" not found`,
+        );
       });
   });
 
@@ -98,7 +106,9 @@ describe('Partners API (e2e)', () => {
     });
 
     return server
-      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partnerName)}`)
+      .get(
+        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partnerName)}`,
+      )
       .expect(200)
       .then(async ({ body }) => {
         expect(body).toHaveProperty('id', partner.id);
@@ -117,7 +127,9 @@ describe('Partners API (e2e)', () => {
     });
 
     return server
-      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partnerName)}`)
+      .get(
+        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partnerName)}`,
+      )
       .expect(200)
       .then(async ({ body }) => {
         expect(body).toHaveProperty('id', partner.id);
@@ -136,7 +148,9 @@ describe('Partners API (e2e)', () => {
 
     // Test without any authentication headers
     return server
-      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`)
+      .get(
+        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`,
+      )
       .expect(200)
       .then(async ({ body }) => {
         expect(body).toHaveProperty('id', partner.id);
@@ -154,7 +168,9 @@ describe('Partners API (e2e)', () => {
     });
 
     return server
-      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`)
+      .get(
+        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`,
+      )
       .expect(200)
       .then(async ({ body }) => {
         expect(body).toHaveProperty('id', partner.id);

--- a/api-server/test/partners.e2e-spec.ts
+++ b/api-server/test/partners.e2e-spec.ts
@@ -1,0 +1,165 @@
+import request from 'supertest';
+import { PORT } from '../src/constants';
+import { ChildProcessWithoutNullStreams } from 'child_process';
+import { StartedTestContainer } from 'testcontainers';
+import { PartnerModel } from '../src/users/models/partner.model';
+import { TestingModule } from '@nestjs/testing';
+import startDatabase from './test-helpers/e2e-stack/start-database';
+import runMigrations from './test-helpers/e2e-stack/run-migrations';
+import startApplication from './test-helpers/e2e-stack/start-application';
+import buildDbConnectionsForTests from './test-helpers/e2e-stack/build-db-connection-for-tests';
+import { CURRENT_VERSION_URI } from '../src/utils/versionts';
+import { afterAllStackShutdown } from './test-helpers/after-all-stack-shutdown';
+import { v4 as uuidv4 } from 'uuid';
+
+describe('Partners API (e2e)', () => {
+  const server = request('http://localhost:' + PORT);
+
+  let appUnderTest: ChildProcessWithoutNullStreams;
+  let dbContainer: StartedTestContainer;
+
+  let partnerModel: typeof PartnerModel;
+  let testingModule: TestingModule;
+
+  let dbHostPort: number;
+
+  beforeAll(async () => {
+    console.info('preparing Partners API test suite');
+
+    const dbInfo = await startDatabase();
+
+    dbContainer = dbInfo.dbContainer;
+    dbHostPort = dbInfo.dbHostPort;
+
+    await runMigrations(dbHostPort);
+
+    appUnderTest = await startApplication(dbHostPort);
+
+    const databaseModels = await buildDbConnectionsForTests(dbHostPort);
+
+    partnerModel = databaseModels.partnerModel;
+
+    testingModule = databaseModels.testingModule;
+
+    console.log('Partners API test suite ready');
+
+    return Promise.resolve();
+  }, 30000);
+
+  afterEach(async () => {
+    await partnerModel.destroy({ where: {} });
+
+    return Promise.resolve();
+  });
+
+  afterAll(
+    async () => afterAllStackShutdown(appUnderTest, dbContainer, testingModule),
+    30000,
+  );
+
+  it('/partners/{name} should return a partner when found', async () => {
+    // Create a partner
+    const partner = await partnerModel.create({
+      id: uuidv4(),
+      name: 'Test Partner Organization',
+      logo_url: 'https://example.com/logo.png',
+    });
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`)
+      .expect(200)
+      .then(async ({ body }) => {
+        expect(body).toHaveProperty('id', partner.id);
+        expect(body).toHaveProperty('name', partner.name);
+        expect(body).toHaveProperty('logo_url', partner.logo_url);
+        expect(body).toHaveProperty('createdAt');
+        expect(body).toHaveProperty('updatedAt');
+      });
+  });
+
+  it('/partners/{name} should return 404 when partner not found', async () => {
+    const nonExistentName = 'Non Existent Partner';
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(nonExistentName)}`)
+      .expect(404)
+      .then(async ({ body }) => {
+        expect(body.message).toContain(`Partner with name "${nonExistentName}" not found`);
+      });
+  });
+
+  it('/partners/{name} should handle URL-encoded partner names', async () => {
+    // Create a partner with special characters in the name
+    const partnerName = 'TechCorp & Associates LLC';
+    const partner = await partnerModel.create({
+      id: uuidv4(),
+      name: partnerName,
+      logo_url: 'https://example.com/techcorp-logo.png',
+    });
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partnerName)}`)
+      .expect(200)
+      .then(async ({ body }) => {
+        expect(body).toHaveProperty('id', partner.id);
+        expect(body).toHaveProperty('name', partnerName);
+        expect(body).toHaveProperty('logo_url', partner.logo_url);
+      });
+  });
+
+  it('/partners/{name} should handle partner names with spaces', async () => {
+    // Create a partner with spaces in the name
+    const partnerName = 'Global Tech Solutions Inc';
+    const partner = await partnerModel.create({
+      id: uuidv4(),
+      name: partnerName,
+      logo_url: 'https://example.com/global-tech-logo.png',
+    });
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partnerName)}`)
+      .expect(200)
+      .then(async ({ body }) => {
+        expect(body).toHaveProperty('id', partner.id);
+        expect(body).toHaveProperty('name', partnerName);
+        expect(body).toHaveProperty('logo_url', partner.logo_url);
+      });
+  });
+
+  it('/partners/{name} should not require authentication', async () => {
+    // Create a partner
+    const partner = await partnerModel.create({
+      id: uuidv4(),
+      name: 'Public Partner',
+      logo_url: 'https://example.com/public-logo.png',
+    });
+
+    // Test without any authentication headers
+    return server
+      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`)
+      .expect(200)
+      .then(async ({ body }) => {
+        expect(body).toHaveProperty('id', partner.id);
+        expect(body).toHaveProperty('name', partner.name);
+        expect(body).toHaveProperty('logo_url', partner.logo_url);
+      });
+  });
+
+  it('/partners/{name} should return partner with null logo_url when not set', async () => {
+    // Create a partner without logo_url
+    const partner = await partnerModel.create({
+      id: uuidv4(),
+      name: 'Partner Without Logo',
+      logo_url: null,
+    });
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`)
+      .expect(200)
+      .then(async ({ body }) => {
+        expect(body).toHaveProperty('id', partner.id);
+        expect(body).toHaveProperty('name', partner.name);
+        expect(body).toHaveProperty('logo_url', null);
+      });
+  });
+});

--- a/api-server/test/partners.e2e-spec.ts
+++ b/api-server/test/partners.e2e-spec.ts
@@ -57,7 +57,7 @@ describe('Partners API (e2e)', () => {
     30000,
   );
 
-  it('/partners/{name} should return a partner when found', async () => {
+  it('/partners/name/{name} should return a partner when found', async () => {
     // Create a partner
     const partner = await partnerModel.create({
       id: uuidv4(),
@@ -67,7 +67,9 @@ describe('Partners API (e2e)', () => {
 
     return server
       .get(
-        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`,
+        `/${CURRENT_VERSION_URI}/partners/name/${encodeURIComponent(
+          partner.name,
+        )}`,
       )
       .expect(200)
       .then(async ({ body }) => {
@@ -79,12 +81,12 @@ describe('Partners API (e2e)', () => {
       });
   });
 
-  it('/partners/{name} should return 404 when partner not found', async () => {
+  it('/partners/name/{name} should return 404 when partner not found', async () => {
     const nonExistentName = 'Non Existent Partner';
 
     return server
       .get(
-        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(
+        `/${CURRENT_VERSION_URI}/partners/name/${encodeURIComponent(
           nonExistentName,
         )}`,
       )
@@ -96,7 +98,7 @@ describe('Partners API (e2e)', () => {
       });
   });
 
-  it('/partners/{name} should handle URL-encoded partner names', async () => {
+  it('/partners/name/{name} should handle URL-encoded partner names', async () => {
     // Create a partner with special characters in the name
     const partnerName = 'TechCorp & Associates LLC';
     const partner = await partnerModel.create({
@@ -107,7 +109,9 @@ describe('Partners API (e2e)', () => {
 
     return server
       .get(
-        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partnerName)}`,
+        `/${CURRENT_VERSION_URI}/partners/name/${encodeURIComponent(
+          partnerName,
+        )}`,
       )
       .expect(200)
       .then(async ({ body }) => {
@@ -117,7 +121,7 @@ describe('Partners API (e2e)', () => {
       });
   });
 
-  it('/partners/{name} should handle partner names with spaces', async () => {
+  it('/partners/name/{name} should handle partner names with spaces', async () => {
     // Create a partner with spaces in the name
     const partnerName = 'Global Tech Solutions Inc';
     const partner = await partnerModel.create({
@@ -128,7 +132,9 @@ describe('Partners API (e2e)', () => {
 
     return server
       .get(
-        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partnerName)}`,
+        `/${CURRENT_VERSION_URI}/partners/name/${encodeURIComponent(
+          partnerName,
+        )}`,
       )
       .expect(200)
       .then(async ({ body }) => {
@@ -138,7 +144,7 @@ describe('Partners API (e2e)', () => {
       });
   });
 
-  it('/partners/{name} should not require authentication', async () => {
+  it('/partners/name/{name} should not require authentication', async () => {
     // Create a partner
     const partner = await partnerModel.create({
       id: uuidv4(),
@@ -149,7 +155,9 @@ describe('Partners API (e2e)', () => {
     // Test without any authentication headers
     return server
       .get(
-        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`,
+        `/${CURRENT_VERSION_URI}/partners/name/${encodeURIComponent(
+          partner.name,
+        )}`,
       )
       .expect(200)
       .then(async ({ body }) => {
@@ -159,7 +167,7 @@ describe('Partners API (e2e)', () => {
       });
   });
 
-  it('/partners/{name} should return partner with null logo_url when not set', async () => {
+  it('/partners/name/{name} should return partner with null logo_url when not set', async () => {
     // Create a partner without logo_url
     const partner = await partnerModel.create({
       id: uuidv4(),
@@ -169,7 +177,9 @@ describe('Partners API (e2e)', () => {
 
     return server
       .get(
-        `/${CURRENT_VERSION_URI}/partners/${encodeURIComponent(partner.name)}`,
+        `/${CURRENT_VERSION_URI}/partners/name/${encodeURIComponent(
+          partner.name,
+        )}`,
       )
       .expect(200)
       .then(async ({ body }) => {

--- a/api-server/test/test-helpers/bring-up-stack-and-establish-db-entities.ts
+++ b/api-server/test/test-helpers/bring-up-stack-and-establish-db-entities.ts
@@ -20,6 +20,7 @@ export default async function bringUpStackAndEstablishDbEntities() {
   const venueModel = databaseModels.venueModel;
   const datetimeVenueModel = databaseModels.datetimeVenueModel;
   const partnerModel = databaseModels.partnerModel;
+  const userModel = databaseModels.userModel;
 
   const testingModule = databaseModels.testingModule;
 
@@ -33,6 +34,7 @@ export default async function bringUpStackAndEstablishDbEntities() {
     venueModel,
     datetimeVenueModel,
     partnerModel,
+    userModel,
     testingModule,
   };
 }

--- a/api-server/test/test-helpers/bring-up-stack-and-establish-db-entities.ts
+++ b/api-server/test/test-helpers/bring-up-stack-and-establish-db-entities.ts
@@ -19,6 +19,7 @@ export default async function bringUpStackAndEstablishDbEntities() {
   const eventModel = databaseModels.eventModel;
   const venueModel = databaseModels.venueModel;
   const datetimeVenueModel = databaseModels.datetimeVenueModel;
+  const partnerModel = databaseModels.partnerModel;
 
   const testingModule = databaseModels.testingModule;
 
@@ -31,6 +32,7 @@ export default async function bringUpStackAndEstablishDbEntities() {
     eventModel,
     venueModel,
     datetimeVenueModel,
+    partnerModel,
     testingModule,
   };
 }

--- a/api-server/test/test-helpers/clear-database-entries.ts
+++ b/api-server/test/test-helpers/clear-database-entries.ts
@@ -2,12 +2,15 @@ import { DatetimeVenueModel } from '../../src/events/models/datetime-venue.model
 import { EventModel } from '../../src/events/models/event.model';
 import { VenueModel } from '../../src/venues/models/venue.model';
 import { PartnerModel } from '../../src/users/models/partner.model';
+import { UserModel } from '../../src/users/users.modules';
+import isNotNullOrUndefined from '../../src/utils/is-not-null-or-undefined';
 
 type BringDownDatabaseEntitiesProps = {
   datetimeVenueModel: typeof DatetimeVenueModel;
   eventModel: typeof EventModel;
   venueModel: typeof VenueModel;
   partnerModel?: typeof PartnerModel;
+  userModel?: typeof UserModel;
 };
 
 export default async function clearDatabaseEntries({
@@ -15,11 +18,17 @@ export default async function clearDatabaseEntries({
   eventModel,
   venueModel,
   partnerModel,
+  userModel,
 }: BringDownDatabaseEntitiesProps) {
   await datetimeVenueModel.destroy({ where: {} });
   await eventModel.destroy({ where: {} });
   await venueModel.destroy({ where: {} });
-  if (partnerModel) {
+
+  if (isNotNullOrUndefined(userModel)) {
+    await userModel.destroy({ where: {} });
+  }
+
+  if (isNotNullOrUndefined(partnerModel)) {
     await partnerModel.destroy({ where: {} });
   }
 }

--- a/api-server/test/test-helpers/clear-database-entries.ts
+++ b/api-server/test/test-helpers/clear-database-entries.ts
@@ -1,19 +1,25 @@
 import { DatetimeVenueModel } from '../../src/events/models/datetime-venue.model';
 import { EventModel } from '../../src/events/models/event.model';
 import { VenueModel } from '../../src/venues/models/venue.model';
+import { PartnerModel } from '../../src/users/models/partner.model';
 
 type BringDownDatabaseEntitiesProps = {
   datetimeVenueModel: typeof DatetimeVenueModel;
   eventModel: typeof EventModel;
   venueModel: typeof VenueModel;
+  partnerModel?: typeof PartnerModel;
 };
 
 export default async function clearDatabaseEntries({
   datetimeVenueModel,
   eventModel,
   venueModel,
+  partnerModel,
 }: BringDownDatabaseEntitiesProps) {
   await datetimeVenueModel.destroy({ where: {} });
   await eventModel.destroy({ where: {} });
   await venueModel.destroy({ where: {} });
+  if (partnerModel) {
+    await partnerModel.destroy({ where: {} });
+  }
 }

--- a/api-server/test/test-helpers/e2e-stack/build-db-connection-for-tests.ts
+++ b/api-server/test/test-helpers/e2e-stack/build-db-connection-for-tests.ts
@@ -7,6 +7,7 @@ import { EventsService } from '../../../src/events/events.service';
 import { VenuesService } from '../../../src/venues/venues.service';
 import { AnnouncementModel } from '../../../src/announcements/models/announcement.model';
 import { AnnouncementsService } from '../../../src/announcements/announcements.service';
+import { PartnerModel } from '../../../src/users/models/partner.model';
 import BitlyService from '../../../src/events/bitly.service';
 import { WinstonModule } from 'nest-winston';
 import { format, transports } from 'winston';
@@ -38,6 +39,7 @@ async function buildDbConnectionsForTests(
           AnnouncementModel,
           DatetimeVenueModel,
           EventAdminMetadataModel,
+          PartnerModel,
         ],
       }),
       SequelizeModule.forFeature([
@@ -46,6 +48,7 @@ async function buildDbConnectionsForTests(
         AnnouncementModel,
         DatetimeVenueModel,
         EventAdminMetadataModel,
+        PartnerModel,
       ]),
       WinstonModule.forRoot({
         transports: [
@@ -84,12 +87,16 @@ async function buildDbConnectionsForTests(
   const datetimeVenueModel = testingModule.get(
     `DatetimeVenueModel${NUXT_INTERNAL_POSTFIX}`,
   ) as typeof DatetimeVenueModel;
+  const partnerModel = testingModule.get(
+    `PartnerModel${NUXT_INTERNAL_POSTFIX}`,
+  ) as typeof PartnerModel;
 
   return {
     eventModel,
     venueModel,
     datetimeVenueModel,
     announcementModel,
+    partnerModel,
     testingModule,
   };
 }
@@ -101,5 +108,6 @@ export type DatabaseModels = {
   venueModel: typeof VenueModel;
   datetimeVenueModel: typeof DatetimeVenueModel;
   announcementModel: typeof AnnouncementModel;
+  partnerModel: typeof PartnerModel;
   testingModule: TestingModule;
 };

--- a/api-server/test/test-helpers/e2e-stack/build-db-connection-for-tests.ts
+++ b/api-server/test/test-helpers/e2e-stack/build-db-connection-for-tests.ts
@@ -8,6 +8,7 @@ import { VenuesService } from '../../../src/venues/venues.service';
 import { AnnouncementModel } from '../../../src/announcements/models/announcement.model';
 import { AnnouncementsService } from '../../../src/announcements/announcements.service';
 import { PartnerModel } from '../../../src/users/models/partner.model';
+import { UserModel } from '../../../src/users/models/user.model';
 import BitlyService from '../../../src/events/bitly.service';
 import { WinstonModule } from 'nest-winston';
 import { format, transports } from 'winston';
@@ -40,6 +41,7 @@ async function buildDbConnectionsForTests(
           DatetimeVenueModel,
           EventAdminMetadataModel,
           PartnerModel,
+          UserModel,
         ],
       }),
       SequelizeModule.forFeature([
@@ -49,6 +51,7 @@ async function buildDbConnectionsForTests(
         DatetimeVenueModel,
         EventAdminMetadataModel,
         PartnerModel,
+        UserModel,
       ]),
       WinstonModule.forRoot({
         transports: [
@@ -90,6 +93,9 @@ async function buildDbConnectionsForTests(
   const partnerModel = testingModule.get(
     `PartnerModel${NUXT_INTERNAL_POSTFIX}`,
   ) as typeof PartnerModel;
+  const userModel = testingModule.get(
+    `UserModel${NUXT_INTERNAL_POSTFIX}`,
+  ) as typeof UserModel;
 
   return {
     eventModel,
@@ -97,6 +103,7 @@ async function buildDbConnectionsForTests(
     datetimeVenueModel,
     announcementModel,
     partnerModel,
+    userModel,
     testingModule,
   };
 }
@@ -109,5 +116,6 @@ export type DatabaseModels = {
   datetimeVenueModel: typeof DatetimeVenueModel;
   announcementModel: typeof AnnouncementModel;
   partnerModel: typeof PartnerModel;
+  userModel: typeof UserModel;
   testingModule: TestingModule;
 };

--- a/api-server/test/users.e2e-spec.ts
+++ b/api-server/test/users.e2e-spec.ts
@@ -101,6 +101,8 @@ describe('Users (e2e)', () => {
           expect(response.body.name).toBeDefined();
           expect(response.body.nickname).toBeDefined();
           expect(response.body.isInfiniteAdmin).toEqual(true);
+          expect(response.body.partners).toBeDefined();
+          expect(response.body.partners).toEqual([]);
 
           // Verify user exists in database
           const createdUser = await userModel.findByPk(response.body.id);
@@ -166,6 +168,23 @@ describe('Users (e2e)', () => {
         .expect(200)
         .then(async (response) => {
           expect(response.body.id).toEqual(userId);
+
+          // Verify partners are included in the response
+          expect(response.body.partners).toBeDefined();
+          expect(response.body.partners).toHaveLength(2);
+          expect(response.body.partners.map((p: any) => p.id)).toContain(
+            partner1.id,
+          );
+          expect(response.body.partners.map((p: any) => p.id)).toContain(
+            partner2.id,
+          );
+
+          // Verify partner structure in response
+          expect(response.body.partners[0]).toHaveProperty('id');
+          expect(response.body.partners[0]).toHaveProperty('name');
+          expect(response.body.partners[0]).toHaveProperty('logo_url');
+          expect(response.body.partners[0]).toHaveProperty('createdAt');
+          expect(response.body.partners[0]).toHaveProperty('updatedAt');
 
           // Verify user has partners associated in the database
           const userWithPartners = await userModel.findByPk(userId, {

--- a/api-server/test/users.e2e-spec.ts
+++ b/api-server/test/users.e2e-spec.ts
@@ -238,7 +238,9 @@ describe('Users (e2e)', () => {
 
   describe('GET /users/current/partners', () => {
     it('should return 403 when user is not authenticated', async () => {
-      return server.get(`/${CURRENT_VERSION_URI}/users/current/partners`).expect(403);
+      return server
+        .get(`/${CURRENT_VERSION_URI}/users/current/partners`)
+        .expect(403);
     });
 
     it('should return empty partners list for user with no partners', async () => {

--- a/api-server/test/users.e2e-spec.ts
+++ b/api-server/test/users.e2e-spec.ts
@@ -1,0 +1,248 @@
+import startDatabase from './test-helpers/e2e-stack/start-database';
+import runMigrations from './test-helpers/e2e-stack/run-migrations';
+import startApplication from './test-helpers/e2e-stack/start-application';
+import buildDbConnectionsForTests from './test-helpers/e2e-stack/build-db-connection-for-tests';
+import request from 'supertest';
+import { ChildProcessWithoutNullStreams } from 'child_process';
+import { StartedTestContainer } from 'testcontainers';
+import { TestingModule } from '@nestjs/testing';
+import { UserModel } from '../src/users/models/user.model';
+import { PartnerModel } from '../src/users/models/partner.model';
+import killApp from './test-helpers/e2e-stack/kill-app';
+import stopDatabase from './test-helpers/e2e-stack/stop-database';
+import isNotNullOrUndefined from '../src/utils/is-not-null-or-undefined';
+import { CURRENT_VERSION_URI } from '../src/utils/versionts';
+import { v4 as uuidv4 } from 'uuid';
+import { PORT } from '../src/constants';
+import createJwtForRandomUser from './test-helpers/creaeteJwt';
+import generatePartnerRequest from './fakers/partner.faker';
+
+const server = request('http://localhost:' + PORT);
+
+let appUnderTest: ChildProcessWithoutNullStreams;
+let dbContainer: StartedTestContainer;
+
+let userModel: typeof UserModel;
+let partnerModel: typeof PartnerModel;
+let testingModule: TestingModule;
+
+let dbHostPort: number;
+
+describe('Users (e2e)', () => {
+  beforeAll(async () => {
+    console.info('preparing for test suite -- Users');
+
+    const dbInfo = await startDatabase();
+
+    dbContainer = dbInfo.dbContainer;
+    dbHostPort = dbInfo.dbHostPort;
+
+    await runMigrations(dbHostPort);
+
+    appUnderTest = await startApplication(dbHostPort);
+
+    const databaseModels = await buildDbConnectionsForTests(dbHostPort);
+
+    userModel = databaseModels.userModel;
+    partnerModel = databaseModels.partnerModel;
+    testingModule = databaseModels.testingModule;
+
+    console.info('test suite ready');
+
+    return Promise.resolve();
+  }, 30000);
+
+  afterAll(async () => {
+    console.info('begin cleanup for users');
+
+    await killApp(appUnderTest);
+
+    if (appUnderTest) {
+      appUnderTest.removeAllListeners();
+    }
+
+    await stopDatabase(dbContainer);
+
+    if (isNotNullOrUndefined(testingModule)) await testingModule.close();
+
+    console.info('done cleaning up for users');
+    return Promise.resolve();
+  });
+
+  beforeEach(async () => {
+    await deleteAllUsersAndPartners();
+  });
+
+  describe('GET /users/current', () => {
+    it('should return 403 when user is not authenticated', async () => {
+      return server.get(`/${CURRENT_VERSION_URI}/users/current`).expect(403);
+    });
+
+    it('should create a new user when user does not exist', async () => {
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': true,
+      });
+
+      // Verify no users exist initially
+      const initialUserCount = await userModel.count();
+      expect(initialUserCount).toEqual(0);
+
+      return server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(async (response) => {
+          // Verify user was created
+          const finalUserCount = await userModel.count();
+          expect(finalUserCount).toEqual(1);
+
+          // Verify response structure
+          expect(response.body.id).toBeDefined();
+          expect(response.body.name).toBeDefined();
+          expect(response.body.nickname).toBeDefined();
+          expect(response.body.isInfiniteAdmin).toEqual(true);
+
+          // Verify user exists in database
+          const createdUser = await userModel.findByPk(response.body.id);
+          expect(createdUser).toBeDefined();
+          expect(createdUser.name).toEqual(response.body.name);
+        });
+    });
+
+    it('should return existing user when user already exists', async () => {
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': true,
+      });
+
+      // Create a user first
+      const firstResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200);
+
+      const firstUserId = firstResponse.body.id;
+
+      // Call the endpoint again
+      return server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(async (response) => {
+          // Should return the same user
+          expect(response.body.id).toEqual(firstUserId);
+          expect(response.body.name).toEqual(firstResponse.body.name);
+          expect(response.body.nickname).toEqual(firstResponse.body.nickname);
+
+          // Should still have only one user in database
+          const userCount = await userModel.count();
+          expect(userCount).toEqual(1);
+        });
+    });
+
+    it('should return existing user with associated partners', async () => {
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': true,
+      });
+
+      // Create a user first
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200);
+
+      const userId = userResponse.body.id;
+
+      // Create some partners
+      const partner1 = await createPartner(generatePartnerRequest());
+      const partner2 = await createPartner(generatePartnerRequest());
+
+      // Associate user with partners
+      await associateUserWithPartners(userId, [partner1.id, partner2.id]);
+
+      // Call the endpoint again and verify partners are loaded
+      return server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(async (response) => {
+          expect(response.body.id).toEqual(userId);
+
+          // Verify user has partners associated in the database
+          const userWithPartners = await userModel.findByPk(userId, {
+            include: [
+              {
+                model: PartnerModel,
+                as: 'partners',
+                through: { attributes: [] },
+              },
+            ],
+          });
+
+          expect(userWithPartners.partners).toHaveLength(2);
+          expect(userWithPartners.partners.map((p) => p.id)).toContain(
+            partner1.id,
+          );
+          expect(userWithPartners.partners.map((p) => p.id)).toContain(
+            partner2.id,
+          );
+        });
+    });
+
+    it('should return user info with correct admin status', async () => {
+      const adminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': true,
+      });
+
+      // Test admin user
+      await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': adminToken })
+        .expect(200)
+        .then((response) => {
+          expect(response.body.isInfiniteAdmin).toEqual(true);
+        });
+
+      const nonAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      // Test non-admin user
+      await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': nonAdminToken })
+        .expect(200)
+        .then((response) => {
+          expect(response.body.isInfiniteAdmin).toEqual(false);
+        });
+    });
+  });
+
+  async function createPartner(partnerData: any): Promise<PartnerModel> {
+    return partnerModel.create({
+      ...partnerData,
+      id: uuidv4(),
+    });
+  }
+
+  async function associateUserWithPartners(
+    userId: string,
+    partnerIds: string[],
+  ): Promise<void> {
+    // Use Sequelize's association methods to create the many-to-many relationship
+    const user = await userModel.findByPk(userId);
+    const partners = await partnerModel.findAll({
+      where: { id: partnerIds },
+    });
+
+    // Use the association method to set partners
+    await (user as any).setPartners(partners);
+  }
+
+  async function deleteAllUsersAndPartners(): Promise<void> {
+    // Delete all users first (this will cascade delete the mappings due to foreign key constraints)
+    await userModel.destroy({ where: {} });
+
+    // Delete all partners
+    await partnerModel.destroy({ where: {} });
+  }
+});

--- a/api-server/test/venues.e2e-spec.ts
+++ b/api-server/test/venues.e2e-spec.ts
@@ -144,7 +144,7 @@ describe('Venues (e2e)', () => {
         expect(venueResp).toBeTruthy();
 
         expect(response.body.venue).not.toEqual(originalModelAsJson);
-        assertVenuesEqualIgnoringDateStamps(venueResp, expectedModel);
+        assertVenuesEqualIgnoringDateStampsAndLatLong(venueResp, expectedModel);
       });
   });
 
@@ -193,7 +193,10 @@ describe('Venues (e2e)', () => {
         expect(venueResp).toBeTruthy();
 
         expect(response.body.venue).not.toEqual(originalModelAsJson);
-        assertVenuesEqualIgnoringDateStamps(venueResp, expectedModelResp);
+        assertVenuesEqualIgnoringDateStampsAndLatLong(
+          venueResp,
+          expectedModelResp,
+        );
       });
   });
 
@@ -261,7 +264,7 @@ describe('Venues (e2e)', () => {
         expect(respVenue.createdAt).toBeTruthy();
         expect(respVenue.updatedAt).toBeTruthy();
 
-        assertVenuesEqualIgnoringDateStamps(
+        assertVenuesEqualIgnoringDateStampsAndLatLong(
           respVenueWithoutId,
           expectedRespValue,
         );
@@ -341,12 +344,14 @@ describe('Venues (e2e)', () => {
     };
   }
 
-  function assertVenuesEqualIgnoringDateStamps(
+  function assertVenuesEqualIgnoringDateStampsAndLatLong(
     actualVenueModel: Record<string, unknown>,
     expectedVenueModel: Record<string, unknown>,
   ) {
     const actualModelWithoutDates = new VenueModel({
       ...actualVenueModel,
+      gps_lat: null, // we don't have lat/long service configured when running tests
+      gps_long: null,
       updatedAt: null,
       createdAt: null,
     });

--- a/api-server/todo.md
+++ b/api-server/todo.md
@@ -1,0 +1,8 @@
+Todo -- Partner Integration Feature
+-----------------------------------
+* Create relation table between users and partners, lets make it one user to many partners in case someone is part of two partners
+  * When fetching user info we will return their list of partners
+* Map event to partner table
+  * When fetching an event we will return the partner it belongs to
+* Allow filtering on partner name
+* Delete this file

--- a/api-server/todo.md
+++ b/api-server/todo.md
@@ -6,3 +6,4 @@ Todo -- Partner Integration Feature
   * When fetching an event we will return the partner it belongs to
 * Allow filtering on partner name
 * Delete this file
+* !!! ALOW OWNERS TO APPROVE


### PR DESCRIPTION
1. Created migration to add partner and user/partner membership tables
2. Created migration to add owning_partner_id to the event table
3. Created related sequalize models and updated existing models and dtos to interact with new tables
4. created middle-ware for consolidating the resolution of user information on each request
5. updated guards to leverage the new middle-ware and created new guards to deal with new authenticated situations such as an authenticated user that is not an infinite-admin but may be a partner-admin
6. fixed bug in filtering of organizer contact e-mail that was leaving it on the event for some un-authenticated requests
7. updated filtering logic to leave on organizer-contact and fetch event admin metadata if you are a partner-admin that owns the event via partner association
8. created some basic crud endpoints around partners and partner associations
9. created a new endpoint for fetching all unverified events that belong to you via partner-association (if you are an infinite-admin they all belong to you and it falls through to existing get all unverified logic) 