### PR TITLE
Fix add-to-calendar on event cards

### DIFF
--- a/web-portal/components/EventCard.vue
+++ b/web-portal/components/EventCard.vue
@@ -84,7 +84,7 @@
         const event = this.calendar_event && this.calendar_event.venue
           ? this.calendar_event
           : Object.assign({}, this.calendar_event, { venue: this.venue })
-        CalendarService.generate(this.$config.API_URL, event, calType)
+        CalendarService.generate(this.$config.public.apiUrl, event, calType)
       },
       truncate(fullText, truncationLength) {
         if (!fullText) {


### PR DESCRIPTION
We missed the reference to the old `API_URL` env config.