### PR TITLE
Fix frontend handling of image upload errors

### DIFF
--- a/web-portal/pages/submit-event.vue
+++ b/web-portal/pages/submit-event.vue
@@ -175,14 +175,14 @@
   const handleSubmissionError = ({ error }) => {
     mode.value = 'error'
 
-    const errorResp = error?.response
+    const errorResp = error?.data
 
     if (
       errorResp !== null &&
       errorResp !== undefined &&
-      !!errorResp?.data?.message
+      !!errorResp?.message
     ) {
-      submissionErrorMessage.value = errorResp.data.message
+      submissionErrorMessage.value = errorResp.message
     }
   }
 
@@ -329,6 +329,11 @@
   }
 
   .infinite-submission-form__error-message {
-    color: red;
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    border-radius: 1rem;
+    background-color: rgb(var(--v-theme-error));
+    color: white;
+    font-weight: bold;
   }
 </style>


### PR DESCRIPTION
This is a quick fix for the issue noted in today's meeting, that errors from image upload problems on the submission form that previously displayed to the user weren't appearing. Looks like we just overlooked that handling during the Nuxt upgrade, which replaced `axios` with `fetch`, which has different response APIs.

While I was looking at this code I made some styling tweaks to the displayed error message that I think will make it stand out more vs the "please ping us" message.