### PR TITLE
Partner improvements: only show partner's own events if requested

### DIFF
--- a/web-portal/pages/index.vue
+++ b/web-portal/pages/index.vue
@@ -7,8 +7,10 @@
 
     <ii-list-viewer :calendar_events="events" />
 
-    <h2>Online Resources / Projects</h2>
-    <ii-list-viewer :calendar_events="streamEvents" />
+    <template v-if="streamEvents && streamEvents.length > 0">
+      <h2>Online Resources / Projects</h2>
+      <ii-list-viewer :calendar_events="streamEvents" />
+    </template>
   </div>
 </template>
 

--- a/web-portal/pages/remote.vue
+++ b/web-portal/pages/remote.vue
@@ -2,8 +2,10 @@
   <div>
     <ii-list-viewer :calendar_events="events" />
 
-    <h2>Online Resources / Projects</h2>
-    <ii-list-viewer :calendar_events="streamEvents" />
+    <template v-if="streamEvents && streamEvents.length > 0">
+        <h2>Online Resources / Projects</h2>
+        <ii-list-viewer :calendar_events="streamEvents" />
+    </template>
   </div>
 </template>
 

--- a/web-portal/store/index.js
+++ b/web-portal/store/index.js
@@ -125,11 +125,18 @@ export const actions = {
   },
 
   LoadAllLocalEventData: function (context) {
+    const showOnlyPartnerEvents = useNuxtApp().$store.getters['partner/showOnlyPartnerEvents']
+    const partnerId = useNuxtApp().$store.getters['partner/partner']?.id
     context.commit('SET_LOADING_STATUS', true)
 
     return useNuxtApp().$apiService.get(`${CURRENT_EVENTS_VERIFIED_PATH}?${EMBED_VENUE}`)
       .then((data) => {
-        context.commit('UPDATE_LOCALIZED_EVENTS', data.events)
+        context.commit(
+          'UPDATE_LOCALIZED_EVENTS',
+          showOnlyPartnerEvents && partnerId
+            ? data.events.filter((ev) => ev.owning_partner_id === partnerId)
+            : data.events
+        )
         context.commit('SET_LOADING_STATUS', false)
       })
       .catch((error) => {
@@ -138,9 +145,16 @@ export const actions = {
       })
   },
   LoadAllStreamingEventData: function (context) {
+    const showOnlyPartnerEvents = useNuxtApp().$store.getters['partner/showOnlyPartnerEvents']
+    const partnerId = useNuxtApp().$store.getters['partner/partner']?.id
     return useNuxtApp().$apiService.get(`${EVENTS_VERIFIED_PATH}?category=online-resource&${EMBED_VENUE}`)
       .then((data) => {
-        context.commit('UPDATE_STREAMING_EVENTS', data.events)
+        context.commit(
+          'UPDATE_STREAMING_EVENTS',
+          showOnlyPartnerEvents && partnerId
+            ? data.events.filter((ev) => ev.owning_partner_id === partnerId)
+            : data.events
+        )
       })
       .catch((error) => {
         console.error(error)

--- a/web-portal/store/partner.js
+++ b/web-portal/store/partner.js
@@ -4,12 +4,17 @@ export const state = () => ({
   // string | null
   name: null,
   // { id: string; name: string; light_logo_url: string; dark_logo_url: string } | null
-  partner: null
+  partner: null,
+  // boolean
+  showOnlyPartnerEvents: false,
 })
 
 export const getters = {
   partner: (state) => {
     return state.partner
+  },
+  showOnlyPartnerEvents: (state) => {
+    return state.showOnlyPartnerEvents ?? false;
   }
 }
 
@@ -17,6 +22,9 @@ export const mutations = {
   SET_PARTNER: (state, payload) => {
     state.name = payload?.name ?? null
     state.partner = payload
+  },
+  SET_SHOW_ONLY_PARTNER_EVENTS: (state, payload) => {
+    state.showOnlyPartnerEvents = payload && payload.toLowerCase() === "partner"
   }
 }
 
@@ -33,6 +41,9 @@ export const actions = {
         console.error(error, error.value)
       } else {
         context.commit('SET_PARTNER', data.value)
+        if (typeof query.only !== 'undefined') {
+          context.commit('SET_SHOW_ONLY_PARTNER_EVENTS', query.only)
+        }
       }
     }
   }


### PR DESCRIPTION
Pursuant to this morning's discussion, this PR adds support on the web portal for an `only` query param, which, when set to `partner` and paired with the `partner` param, will _only_ include that partner's events on the home page.

This filtering is implemented in the Vuex store, which makes the logic for requesting the events messier than I'd like, but we can consider moving it to the API later, once we've established this is behavior we event want.

I've also added logic on the home page (and the old `/remote` page, which we don't expose in the nav anymore) to suppress the "Online Resources / Projects" subheading if the result of filtering the remote events is an empty set.