### PR TITLE
Venue/Partner Association Part I

### DIFF
--- a/api-server/migrations/20260313155014-create-venues-partners-mappings.js
+++ b/api-server/migrations/20260313155014-create-venues-partners-mappings.js
@@ -2,13 +2,13 @@
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
-  async up (queryInterface, Sequelize) {
+  async up(queryInterface, Sequelize) {
     await queryInterface.createTable('venues_partners_mappings', {
       id: {
         allowNull: false,
         primaryKey: true,
         type: Sequelize.UUID,
-        defaultValue: Sequelize.literal('uuid_generate_v4()')
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
       },
       venue_id: {
         type: Sequelize.UUID,
@@ -33,33 +33,33 @@ module.exports = {
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE,
-        defaultValue: Sequelize.literal('now()')
+        defaultValue: Sequelize.literal('now()'),
       },
       updatedAt: {
         allowNull: false,
         type: Sequelize.DATE,
-        defaultValue: Sequelize.literal('now()')
-      }
+        defaultValue: Sequelize.literal('now()'),
+      },
     });
 
     await queryInterface.addConstraint('venues_partners_mappings', {
       fields: ['venue_id', 'partner_id'],
       type: 'unique',
-      name: 'unique_venue_partner_mapping'
+      name: 'unique_venue_partner_mapping',
     });
 
     await queryInterface.addIndex('venues_partners_mappings', {
       fields: ['venue_id'],
-      name: 'idx_venues_partners_mappings_venue_id'
+      name: 'idx_venues_partners_mappings_venue_id',
     });
 
     await queryInterface.addIndex('venues_partners_mappings', {
       fields: ['partner_id'],
-      name: 'idx_venues_partners_mappings_partner_id'
+      name: 'idx_venues_partners_mappings_partner_id',
     });
   },
 
-  async down (queryInterface, Sequelize) {
+  async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('venues_partners_mappings');
-  }
+  },
 };

--- a/api-server/migrations/20260313155014-create-venues-partners-mappings.js
+++ b/api-server/migrations/20260313155014-create-venues-partners-mappings.js
@@ -1,0 +1,65 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.createTable('venues_partners_mappings', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()')
+      },
+      venue_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'venues',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      partner_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'partners',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('now()')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('now()')
+      }
+    });
+
+    await queryInterface.addConstraint('venues_partners_mappings', {
+      fields: ['venue_id', 'partner_id'],
+      type: 'unique',
+      name: 'unique_venue_partner_mapping'
+    });
+
+    await queryInterface.addIndex('venues_partners_mappings', {
+      fields: ['venue_id'],
+      name: 'idx_venues_partners_mappings_venue_id'
+    });
+
+    await queryInterface.addIndex('venues_partners_mappings', {
+      fields: ['partner_id'],
+      name: 'idx_venues_partners_mappings_partner_id'
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('venues_partners_mappings');
+  }
+};

--- a/api-server/src/authentication/authentication.controller.ts
+++ b/api-server/src/authentication/authentication.controller.ts
@@ -23,8 +23,7 @@ import {
   AUTH_USE_TEST_USERS,
 } from '../constants';
 import createJWTForTestUser from './utils/createJWTForTestUser';
-import UsersService from '../users/users.service';
-import { PartnersService } from '../users/partners.service';
+import { TestPartnerService } from './test-partner.service';
 
 @Controller(`${VERSION_1_URI}/authentication`)
 @ApiTags('authentication')
@@ -32,8 +31,7 @@ export class AuthenticationController implements OnModuleInit {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService,
-    private readonly usersService: UsersService,
-    private readonly partnersService: PartnersService,
+    private readonly testPartnerService: TestPartnerService,
   ) {
     if (AUTH_USE_TEST_USERS) {
       this.logger.warn(AUTH_USE_TEST_USERS_WARNING);
@@ -42,7 +40,7 @@ export class AuthenticationController implements OnModuleInit {
 
   async onModuleInit() {
     if (AUTH_USE_TEST_USERS) {
-      await this.ensureTestPartnerUser();
+      await this.testPartnerService.ensureTestPartnerUser();
     }
   }
 
@@ -140,55 +138,6 @@ export class AuthenticationController implements OnModuleInit {
         'there was an unknown problem performing login',
         500,
       );
-    }
-  }
-
-  private async ensureTestPartnerUser() {
-    this.logger.log('Ensuring partner-admin user exists...');
-
-    // Ensure the user exists
-    const testPartnerUser = await this.usersService.ensureByName({
-      name: 'partner-admin',
-      nickname: 'partner-admin',
-      picture: 'https://via.placeholder.com/150',
-    });
-
-    this.logger.log(`Test partner user ensured with ID: ${testPartnerUser.id}`);
-
-    // Ensure the partner exists
-    let partner = await this.partnersService.findByName(
-      'random-displacement-shipping',
-    );
-
-    if (!partner) {
-      this.logger.log('Creating random-displacement-shipping partner...');
-      partner = await this.partnersService.create({
-        name: 'random-displacement-shipping',
-        light_logo_url: '/images/partners/random-displacement-shipping.png',
-        dark_logo_url: '/images/partners/random-displacement-shipping.png',
-      });
-      this.logger.log(`Partner created with ID: ${partner.id}`);
-    } else {
-      this.logger.log(
-        `Partner random-displacement-shipping already exists with ID: ${partner.id}`,
-      );
-    }
-
-    // Associate the user with the partner (if not already associated)
-    try {
-      await this.partnersService.associateUserWithPartner({
-        user_id: testPartnerUser.id,
-        partner_id: partner.id,
-      });
-      this.logger.log(
-        'Successfully associated partner-admin user with partner',
-      );
-    } catch (error) {
-      if (error.message?.includes('already associated')) {
-        this.logger.log('User is already associated with partner');
-      } else {
-        throw error;
-      }
     }
   }
 }

--- a/api-server/src/authentication/authentication.module.ts
+++ b/api-server/src/authentication/authentication.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AuthenticationController } from './authentication.controller';
 import { UsersModules } from '../users/users.modules';
+import { TestPartnerService } from './test-partner.service';
 
 @Module({
   imports: [UsersModules],
   controllers: [AuthenticationController],
+  providers: [TestPartnerService],
 })
 export class AuthenticationModule {}

--- a/api-server/src/authentication/authentication.module.ts
+++ b/api-server/src/authentication/authentication.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AuthenticationController } from './authentication.controller';
 import { UsersModules } from '../users/users.modules';
+import { VenuesModule } from '../venues/venues.module';
 import { TestPartnerService } from './test-partner.service';
 
 @Module({
-  imports: [UsersModules],
+  imports: [UsersModules, VenuesModule],
   controllers: [AuthenticationController],
   providers: [TestPartnerService],
 })

--- a/api-server/src/authentication/filters/remove-sensitive-data-for-non-admins.ts
+++ b/api-server/src/authentication/filters/remove-sensitive-data-for-non-admins.ts
@@ -77,22 +77,44 @@ export function isOwner(
   event: EventDTO | EventModel,
   request: RequestWithUserInfo,
 ) {
+  // infinite admin is always an owner
   if (request.userInformation?.isInfiniteAdmin) {
-    // infinite admins own all events
     return true;
   }
 
+  // if you're not at least a partner-admin you don't own anything
   if (!request.userInformation?.isPartnerAdmin) {
-    // not a partner admin can't own anything
     return false;
   }
 
-  // check if the event belongs to own of their partnerships
-  return isNotNullOrUndefined(
-    request.userInformation.partners.find(
-      (p) => p.id === event.owning_partner_id,
-    ),
+  // check if the event was submitted via a partner url associated with the user
+  const userPartnerIds = new Set(
+    request.userInformation.partners.map((p) => p.id),
   );
+  if (
+    isNotNullOrUndefined(event.owning_partner_id) &&
+    userPartnerIds.has(event.owning_partner_id)
+  ) {
+    // the user owns this event because they are a partner-admin for a partnership
+    // and this partnership url was used when the event was submitted
+    return true;
+  }
+
+  // treat users as owners if any venue on the event is associated with one of
+  // their partners
+  const venues = getVenues(event);
+  return venues.some((venue) =>
+    (venue.partners ?? []).some((p) => userPartnerIds.has(p.id)),
+  );
+}
+
+function getVenues(
+  event: EventDTO | EventModel,
+): Array<{ partners?: Array<{ id: string }> }> {
+  if (isEventModel(event)) {
+    return event.venues ?? [];
+  }
+  return event.venue ? [event.venue] : [];
 }
 
 function isGenericEventList(arg: EventOrEventList): arg is EventDTO[] {

--- a/api-server/src/authentication/test-partner.service.ts
+++ b/api-server/src/authentication/test-partner.service.ts
@@ -2,6 +2,9 @@ import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import UsersService from '../users/users.service';
 import { PartnersService } from '../users/partners.service';
+import { VenuesService } from '../venues/venues.service';
+import { PartnerModel } from '../users/models/partner.model';
+import { CreateVenueRequest } from '../venues/dto/create-update-venue-request';
 
 @Injectable()
 export class TestPartnerService {
@@ -10,6 +13,7 @@ export class TestPartnerService {
     private readonly logger: LoggerService,
     private readonly usersService: UsersService,
     private readonly partnersService: PartnersService,
+    private readonly venuesService: VenuesService,
   ) {}
 
   async ensureTestPartnerUser(): Promise<void> {
@@ -55,6 +59,71 @@ export class TestPartnerService {
       } else {
         throw error;
       }
+    }
+
+    await this.ensureTestVenues(partner);
+  }
+
+  private async ensureTestVenues(partner: PartnerModel): Promise<void> {
+    const venues = await this.venuesService.findAll();
+    const existingNames = new Set(venues.map((v) => v.name));
+
+    if (!existingNames.has('Planet Express')) {
+      this.logger.log('Creating Planet Express venue...');
+      const planetExpress = await this.venuesService.create(
+        new CreateVenueRequest({
+          name: 'Planet Express',
+          address: '123 Delivery Lane, New New York, NY 10199',
+          street: '123 Delivery Lane',
+          city: 'New New York',
+          state: 'NY',
+          zip: '10199',
+          neighborhood: 'Downtown',
+        }),
+      );
+      this.logger.log(
+        `Planet Express venue created with ID: ${planetExpress.id}`,
+      );
+
+      try {
+        await this.venuesService.associateVenueWithPartner({
+          venue_id: planetExpress.id,
+          partner_id: partner.id,
+        });
+        this.logger.log(
+          'Successfully associated Planet Express with random-displacement-shipping',
+        );
+      } catch (error) {
+        if (error.message?.includes('already associated')) {
+          this.logger.log(
+            'Planet Express is already associated with random-displacement-shipping',
+          );
+        } else {
+          throw error;
+        }
+      }
+    } else {
+      this.logger.log('Planet Express venue already exists');
+    }
+
+    if (!existingNames.has("Mom's Friendly Robot Company")) {
+      this.logger.log("Creating Mom's Friendly Robot Company venue...");
+      const momsCorp = await this.venuesService.create(
+        new CreateVenueRequest({
+          name: "Mom's Friendly Robot Company",
+          address: '456 Corporate Blvd, New New York, NY 10200',
+          street: '456 Corporate Blvd',
+          city: 'New New York',
+          state: 'NY',
+          zip: '10200',
+          neighborhood: 'Midtown',
+        }),
+      );
+      this.logger.log(
+        `Mom's Friendly Robot Company venue created with ID: ${momsCorp.id}`,
+      );
+    } else {
+      this.logger.log("Mom's Friendly Robot Company venue already exists");
     }
   }
 }

--- a/api-server/src/authentication/test-partner.service.ts
+++ b/api-server/src/authentication/test-partner.service.ts
@@ -1,0 +1,60 @@
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import UsersService from '../users/users.service';
+import { PartnersService } from '../users/partners.service';
+
+@Injectable()
+export class TestPartnerService {
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService,
+    private readonly usersService: UsersService,
+    private readonly partnersService: PartnersService,
+  ) {}
+
+  async ensureTestPartnerUser(): Promise<void> {
+    this.logger.log('Ensuring partner-admin user exists...');
+
+    const testPartnerUser = await this.usersService.ensureByName({
+      name: 'partner-admin',
+      nickname: 'partner-admin',
+      picture: 'https://via.placeholder.com/150',
+    });
+
+    this.logger.log(`Test partner user ensured with ID: ${testPartnerUser.id}`);
+
+    let partner = await this.partnersService.findByName(
+      'random-displacement-shipping',
+    );
+
+    if (!partner) {
+      this.logger.log('Creating random-displacement-shipping partner...');
+      partner = await this.partnersService.create({
+        name: 'random-displacement-shipping',
+        light_logo_url: '/images/partners/random-displacement-shipping.png',
+        dark_logo_url: '/images/partners/random-displacement-shipping.png',
+      });
+      this.logger.log(`Partner created with ID: ${partner.id}`);
+    } else {
+      this.logger.log(
+        `Partner random-displacement-shipping already exists with ID: ${partner.id}`,
+      );
+    }
+
+    try {
+      await this.partnersService.associateUserWithPartner({
+        user_id: testPartnerUser.id,
+        partner_id: partner.id,
+      });
+      this.logger.log(
+        'Successfully associated partner-admin user with partner',
+      );
+    } catch (error) {
+      if (error.message?.includes('already associated')) {
+        this.logger.log('User is already associated with partner');
+      } else {
+        throw error;
+      }
+    }
+  }
+}

--- a/api-server/src/events/dto/eventDTO.ts
+++ b/api-server/src/events/dto/eventDTO.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { VenueModel } from '../../venues/models/venue.model';
+import { VenueDTO } from '../../venues/dto/venue-dto';
 import { StartEndTimePairs } from '../../shared-types/start-end-time-pairs';
 import { PartnerDTO } from '../../users/dto/partner-dto';
 
@@ -109,10 +109,8 @@ export default class EventDTO {
   @ApiProperty({ example: [] })
   links: Array<string>;
 
-  // TODO: This should really be returning a DTO rather than VenueModel,
-  // This would help with a lot with awkward cast logic in eventModelToEventDTO
-  @ApiProperty()
-  venue: VenueModel;
+  @ApiProperty({ type: () => VenueDTO })
+  venue: VenueDTO;
 
   @ApiProperty({
     type: () => PartnerDTO,

--- a/api-server/src/events/dto/eventDTO.ts
+++ b/api-server/src/events/dto/eventDTO.ts
@@ -109,6 +109,8 @@ export default class EventDTO {
   @ApiProperty({ example: [] })
   links: Array<string>;
 
+  // TODO: This should really be returning a DTO rather than VenueModel,
+  // This would help with a lot with awkward cast logic in eventModelToEventDTO
   @ApiProperty()
   venue: VenueModel;
 

--- a/api-server/src/events/dto/eventModelToEventDTO.ts
+++ b/api-server/src/events/dto/eventModelToEventDTO.ts
@@ -2,6 +2,7 @@ import { EventModel } from '../models/event.model';
 import EventDTO from './eventDTO';
 import isNotNullOrUndefined from '../../utils/is-not-null-or-undefined';
 import { DatetimeVenueModel } from '../models/datetime-venue.model';
+import { VenueModel } from '../../venues/models/venue.model';
 import { PartnerDTO } from '../../users/dto/partner-dto';
 
 export function eventModelToEventDTO(eventModel: EventModel): EventDTO {
@@ -47,9 +48,13 @@ export function eventModelToEventDTO(eventModel: EventModel): EventDTO {
     website_link: eventModel.website_link,
     multi_day: eventModel.multi_day,
     date_times,
-    venue: isNotNullOrUndefined(eventModel.venues)
-      ? eventModel.venues[0]
-      : null,
+    venue:
+      isNotNullOrUndefined(eventModel.venues) && eventModel.venues[0]
+        ? ({
+            ...eventModel.venues[0].toJSON(),
+            partners: (eventModel.venues[0] as any).partners ?? [],
+          } as VenueModel)
+        : null,
     event_admin_metadata: isNotNullOrUndefined(eventModel.event_admin_metadata)
       ? {
           is_problem: eventModel.event_admin_metadata.is_problem,

--- a/api-server/src/events/dto/eventModelToEventDTO.ts
+++ b/api-server/src/events/dto/eventModelToEventDTO.ts
@@ -2,8 +2,8 @@ import { EventModel } from '../models/event.model';
 import EventDTO from './eventDTO';
 import isNotNullOrUndefined from '../../utils/is-not-null-or-undefined';
 import { DatetimeVenueModel } from '../models/datetime-venue.model';
-import { VenueModel } from '../../venues/models/venue.model';
 import { PartnerDTO } from '../../users/dto/partner-dto';
+import { venueModelToVenueDTO } from '../../venues/dto/venue-model-to-venue-dto';
 
 export function eventModelToEventDTO(eventModel: EventModel): EventDTO {
   const date_times: DatetimeVenueModel[] = isNotNullOrUndefined(
@@ -48,12 +48,12 @@ export function eventModelToEventDTO(eventModel: EventModel): EventDTO {
     website_link: eventModel.website_link,
     multi_day: eventModel.multi_day,
     date_times,
+    // This returns a single venue, the schema supports multiple, but the frontend
+    // can't really deal with that, for the time being we will pretend to the
+    // outside world like there can be only one
     venue:
       isNotNullOrUndefined(eventModel.venues) && eventModel.venues[0]
-        ? ({
-            ...eventModel.venues[0].toJSON(),
-            partners: (eventModel.venues[0] as any).partners ?? [],
-          } as VenueModel)
+        ? venueModelToVenueDTO(eventModel.venues[0])
         : null,
     event_admin_metadata: isNotNullOrUndefined(eventModel.event_admin_metadata)
       ? {

--- a/api-server/src/events/events.authenticated.controller.ts
+++ b/api-server/src/events/events.authenticated.controller.ts
@@ -2,7 +2,6 @@ import {
   Body,
   Controller,
   Delete,
-  ForbiddenException,
   Get,
   Inject,
   LoggerService,
@@ -46,7 +45,7 @@ import { validateAndExtractOptionalDateTimeFilters } from './utils/validateAndEx
 import { AuthenticatedUserGuard } from '../authentication/auth-guards/authenticated-user.guard';
 import { PartnerAdminGuard } from '../authentication/auth-guards/partner-admin.guard';
 import { RequestWithUserInfo } from '../users/dto/RequestWithUserInfo';
-import { Op } from 'sequelize';
+import { Op, literal } from 'sequelize';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 @Controller(`${VERSION_1_URI}/authenticated/events`)
@@ -175,12 +174,12 @@ export default class EventsAuthenticatedController {
   getAllNonVerified(
     @Req() request: RequestWithUserInfo,
   ): Promise<EventsResponse> {
-    const findOptions = {
-      where: { verified: false },
-    };
-
+    // Since infinite admins have access to all partners this will really just return
+    // all non-verified events
+    //
+    // We could consider a future enhancement to let admins filter by a given partner,
     return this.eventsService
-      .findAll(request, findOptions)
+      .findAllNonVerifiedForPartnersBelongToTheCurrentUser(request)
       .then((events) => events.map(eventModelToEventDTO))
       .then((events) => new EventsResponse({ events }));
   }
@@ -194,33 +193,10 @@ export default class EventsAuthenticatedController {
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiBearerAuth()
   async getAllNonVerifiedForPartnersBelongToTheCurrentUser(
-    @Query('embed') embed: string[] | string = [],
     @Req() request: RequestWithUserInfo,
   ): Promise<EventsResponse> {
-    const user = request.userInformation;
-
-    if (user.isInfiniteAdmin) {
-      // infinite admins have access to all partners, it may be useful for admins
-      // to filter by a given partner, but we can implement that as a separate filter
-      // somewhere, this event is specifically a convenience to give an easy way
-      // to get all un-verified events a partner-admin has access to
-      return this.getAllNonVerified(request);
-    }
-
-    const partnerIds = user.partners?.map((partner) => partner.id) || [];
-
-    const findOptions = {
-      ...getOptionsForEventsServiceFromEmbedsQueryParam(embed),
-      where: {
-        verified: false,
-        owning_partner_id: {
-          [Op.in]: partnerIds,
-        },
-      },
-    };
-
     return this.eventsService
-      .findAll(request, findOptions)
+      .findAllNonVerifiedForPartnersBelongToTheCurrentUser(request)
       .then((events) => events.map(eventModelToEventDTO))
       .then((events) => new EventsResponse({ events }));
   }

--- a/api-server/src/events/events.service.ts
+++ b/api-server/src/events/events.service.ts
@@ -91,10 +91,16 @@ export class EventsService {
   private async findOneWithRelated(
     findOptions: FindOptions,
   ): Promise<EventModel> {
-    return await this.eventModel.findOne({
+    const event = await this.eventModel.findOne({
       include: [DatetimeVenueModel, VenueModel, PartnerModel],
       ...findOptions,
     });
+
+    if (event) {
+      await this.populateVenuePartners([event]);
+    }
+
+    return event;
   }
 
   async findAll(
@@ -236,11 +242,26 @@ export class EventsService {
             })
           : [];
 
+      // Derive venues and populate venue partners before the ownership check
+      // so that venue-partner associations are available when isOwner runs
       paginatedRows.forEach((event) => {
         const dateTimesForEvent = dateTimes.filter(
           ({ event_id }) => event_id === event.id,
         );
+        event.date_times = dateTimesForEvent;
 
+        const uniqueVenues = new Map<string, VenueModel>();
+        dateTimesForEvent.forEach((dt) => {
+          if (dt.venue && !uniqueVenues.has(dt.venue.id)) {
+            uniqueVenues.set(dt.venue.id, dt.venue);
+          }
+        });
+        event.venues = [...uniqueVenues.values()];
+      });
+
+      await this.populateVenuePartners(paginatedRows);
+
+      paginatedRows.forEach((event) => {
         // Find and assign the corresponding partner
         const partnerForEvent = event.owning_partner_id
           ? partners.find(({ id }) => id === event.owning_partner_id)
@@ -260,7 +281,6 @@ export class EventsService {
           event.organizer_contact = undefined;
         }
 
-        event.date_times = dateTimesForEvent;
         event.owning_partner = partnerForEvent;
       });
 
@@ -507,21 +527,11 @@ export class EventsService {
     }
   }
 
-  // Warning, this works by side-effect, it modify the partners attribute of the
-  // venue models
-  private async populateVenuePartners(events: EventModel[]): Promise<void> {
-    // get a list of all unique venu ides used in our list of events
-    const venueIds = [
-      ...new Set(
-        events
-          .flatMap(({ venues }) => (venues ?? []).map(({ id }) => id))
-          .filter(isNotNullOrUndefined),
-      ),
-    ];
-
+  private async buildVenuePartnerMap(
+    venueIds: string[],
+  ): Promise<Map<string, PartnerModel[]>> {
     if (venueIds.length === 0) {
-      // nothing more to do
-      return;
+      return new Map();
     }
 
     const mappings = await this.sequelize.query<{
@@ -558,11 +568,23 @@ export class EventsService {
       venueMap.get(venue_id).push(partner);
     });
 
+    return venueMap;
+  }
+
+  private async populateVenuePartners(events: EventModel[]): Promise<void> {
+    const venueIds = [
+      ...new Set(
+        events
+          .flatMap(({ venues }) => (venues ?? []).map(({ id }) => id))
+          .filter(isNotNullOrUndefined),
+      ),
+    ];
+
+    const venueMap = await this.buildVenuePartnerMap(venueIds);
+
     events.forEach((event) => {
       (event.venues ?? []).forEach((venue) => {
-        if (venueMap.has(venue.id)) {
-          venue.partners = venueMap.get(venue.id);
-        }
+        venue.partners = venueMap.get(venue.id) ?? [];
       });
     });
   }

--- a/api-server/src/events/events.service.ts
+++ b/api-server/src/events/events.service.ts
@@ -97,7 +97,7 @@ export class EventsService {
     });
   }
 
-  findAll(
+  async findAll(
     request: RequestWithUserInfo,
     findOptions?: FindOptions,
   ): Promise<EventModel[]> {
@@ -120,7 +120,11 @@ export class EventsService {
       ? { ...defaultOptions, ...findOptions }
       : defaultOptions;
 
-    return this.eventModel.findAll(mergedOptions);
+    const results = await this.eventModel.findAll(mergedOptions);
+
+    await this.populateVenuePartners(results);
+
+    return results;
   }
 
   async findAllPaginated({
@@ -501,6 +505,66 @@ export class EventsService {
 
       return submittedEvent;
     }
+  }
+
+  // Warning, this works by side-effect, it modify the partners attribute of the
+  // venue models
+  private async populateVenuePartners(events: EventModel[]): Promise<void> {
+    // get a list of all unique venu ides used in our list of events
+    const venueIds = [
+      ...new Set(
+        events
+          .flatMap(({ venues }) => (venues ?? []).map(({ id }) => id))
+          .filter(isNotNullOrUndefined),
+      ),
+    ];
+
+    if (venueIds.length === 0) {
+      // nothing more to do
+      return;
+    }
+
+    const mappings = await this.sequelize.query<{
+      venue_id: string;
+      partner_id: string;
+    }>(
+      `SELECT vpm.venue_id, vpm.partner_id
+       FROM venues_partners_mappings vpm
+       WHERE vpm.venue_id IN (:venueIds)`,
+      { replacements: { venueIds }, type: QueryTypes.SELECT },
+    );
+
+    const partnerIds = [
+      ...new Set(mappings.map(({ partner_id }) => partner_id)),
+    ];
+
+    const partners =
+      partnerIds.length > 0
+        ? await this.partnerModel.findAll({
+            where: { id: { [Op.in]: partnerIds } },
+          })
+        : [];
+
+    const partnerMap = new Map(partners.map((p) => [p.id, p]));
+
+    const venueMap = new Map<string, PartnerModel[]>();
+    mappings.forEach(({ venue_id, partner_id }) => {
+      const partner = partnerMap.get(partner_id);
+      if (!partner) return;
+
+      if (!venueMap.has(venue_id)) {
+        venueMap.set(venue_id, []);
+      }
+      venueMap.get(venue_id).push(partner);
+    });
+
+    events.forEach((event) => {
+      (event.venues ?? []).forEach((venue) => {
+        if (venueMap.has(venue.id)) {
+          venue.partners = venueMap.get(venue.id);
+        }
+      });
+    });
   }
 
   private getTagsClauseParams(tags: string[] | string): Nullable<string> {

--- a/api-server/src/events/events.service.ts
+++ b/api-server/src/events/events.service.ts
@@ -9,6 +9,7 @@ import {
 import { InjectModel } from '@nestjs/sequelize';
 import {
   FindOptions,
+  literal,
   Op,
   QueryTypes,
   Transaction,
@@ -106,6 +107,39 @@ export class EventsService {
     return event;
   }
 
+  async findAllNonVerifiedForPartnersBelongToTheCurrentUser(
+    request: RequestWithUserInfo,
+  ): Promise<EventModel[]> {
+    const user = request.userInformation;
+
+    const partnerIds = user.partners?.map((partner) => partner.id) || [];
+
+    // these should be safe since they are fetched from the db but we will
+    // espcape them just in case
+    const partnerIdsList = partnerIds
+      .map((id) => this.sequelize.escape(id))
+      .join(', ');
+    const findOptions = user.isInfiniteAdmin
+      ? { where: { verified: false } } // infinite admins have access to all partners, it may be useful for admins
+      : {
+          where: {
+            verified: false,
+            // We need events where owning_partner_id is one of the user's partners or the event uses a venue
+            // mapped to one of those partners (see subquery). IDs are escaped for the literal subquery.
+            [Op.or]: [
+              { owning_partner_id: { [Op.in]: partnerIds } },
+              literal(`"EventModel"."id" IN (
+            SELECT dv.event_id FROM datetime_venue dv
+            JOIN venues_partners_mappings vpm ON vpm.venue_id = dv.venue_id
+            WHERE vpm.partner_id IN (${partnerIdsList})
+          )`),
+            ],
+          },
+        };
+
+    return this.findAll(request, findOptions);
+  }
+
   async findAll(
     request: RequestWithUserInfo,
     findOptions?: FindOptions,
@@ -164,14 +198,26 @@ export class EventsService {
     }
     return this.sequelize.transaction(async () => {
       const tagClauseParams = this.getTagsClauseParams(tags);
-      const whereClause = this.getWhereClause(
-        tagClauseParams,
-        category,
-        owningPartnerIds,
-        verifiedOnly,
+      const { whereClause, replacements: whereClauseReplacements } =
+        this.getWhereClause(
+          tagClauseParams,
+          category,
+          owningPartnerIds,
+          verifiedOnly,
+          startDate,
+          endDate,
+        );
+
+      const paginatedQueryReplacements: Record<string, unknown> = {
+        ...whereClauseReplacements,
         startDate,
         endDate,
-      );
+        offset: (requestedPage - 1) * pageSize,
+        limit: pageSize,
+      };
+      if (isNotNullOrUndefined(tagClauseParams)) {
+        paginatedQueryReplacements.tagFilter = tagClauseParams;
+      }
 
       // Sort events by the first start_time and apply pagination
       // Note, we have to sort by first_start_time in our common table expression to apply pagination correctly, but we
@@ -179,7 +225,7 @@ export class EventsService {
       // guaranteed to stay the same.
       // We've also added a secondary order by on created_at to ensure that events without start_time like
       // online resources at least sort consistently
-      const paginatedRows: EventModel[] = await this.sequelize.query(
+      const paginatedRows = (await this.sequelize.query(
         `
               with compressed_event as (
                 SELECT
@@ -191,7 +237,7 @@ export class EventsService {
                   ${whereClause}
               GROUP BY (events.id)
               ORDER BY first_start_time DESC, "createdAt" DESC
-              OFFSET ${(requestedPage - 1) * pageSize} LIMIT ${pageSize} )
+              OFFSET :offset LIMIT :limit )
               SELECT events.*
               FROM compressed_event
                        JOIN events ON events.id = compressed_event.id
@@ -200,14 +246,9 @@ export class EventsService {
         {
           type: QueryTypes.SELECT,
           model: EventModel,
-          replacements: {
-            tagFilter: tagClauseParams,
-            categoryFilter: category,
-            startDate,
-            endDate,
-          },
+          replacements: paginatedQueryReplacements,
         },
-      );
+      )) as EventModel[];
 
       // Fill back in nested models date_times and venues
       const dateTimes = await this.dateTimeVenueModel.findAll({
@@ -248,27 +289,18 @@ export class EventsService {
             })
           : [];
 
-      // this will fetch all partnerships referenced on a venue and build a map of venue to partnership
+      // must run before buildVenuePartnerMap
+      this.populateDateTimesAndVenuesForPaginatedEvents(
+        paginatedRows,
+        dateTimes,
+      );
+
+      // Fetch venue-partner mappings (requires event.venues to be populated first)
       const venueIdToPartnershipMap = await this.buildVenuePartnerMap(
         paginatedRows,
       );
 
       paginatedRows.forEach((event) => {
-        // populate date_times field on the event
-        const dateTimesForEvent = dateTimes.filter(
-          ({ event_id }) => event_id === event.id,
-        );
-        event.date_times = dateTimesForEvent;
-
-        // populate venues field on the event
-        const uniqueVenues = new Map<string, VenueModel>();
-        dateTimesForEvent.forEach((dt) => {
-          if (dt.venue && !uniqueVenues.has(dt.venue.id)) {
-            uniqueVenues.set(dt.venue.id, dt.venue);
-          }
-        });
-        event.venues = [...uniqueVenues.values()];
-
         // fills in via side effect partners on the associated venues,
         // this must be done before we apply the isOwner check
         this.populateVenuePartnersForSingleEvent(
@@ -301,6 +333,7 @@ export class EventsService {
       const totalCount = await this.getEventCountWithFilters(
         tagClauseParams,
         whereClause,
+        whereClauseReplacements,
         startDate,
         endDate,
       );
@@ -541,7 +574,30 @@ export class EventsService {
     }
   }
 
-  // Warning: This works via side-effect, setting the partners array on even venues
+  // Warning: mutates each event in place — assigns `date_times` and deduplicated
+  // `venues` from the datetime query rows. Must run before `buildVenuePartnerMap`
+  // so venue IDs are present for partner lookups
+  private populateDateTimesAndVenuesForPaginatedEvents(
+    events: EventModel[],
+    dateTimes: DatetimeVenueModel[],
+  ): void {
+    events.forEach((event) => {
+      const dateTimesForEvent = dateTimes.filter(
+        ({ event_id }) => event_id === event.id,
+      );
+      event.date_times = dateTimesForEvent;
+
+      const uniqueVenues = new Map<string, VenueModel>();
+      dateTimesForEvent.forEach((dt) => {
+        if (dt.venue && !uniqueVenues.has(dt.venue.id)) {
+          uniqueVenues.set(dt.venue.id, dt.venue);
+        }
+      });
+      event.venues = [...uniqueVenues.values()];
+    });
+  }
+
+  // Warning: This works via side effect, setting the partners array on even venues
   private populateVenuePartners(
     events: EventModel[],
     venueIdToPartnershipMap: Map<string, PartnerModel[]>,
@@ -553,6 +609,7 @@ export class EventsService {
     });
   }
 
+  // Warning: This works via side effect, setting the partners array on even venues
   private populateVenuePartnersForSingleEvent(
     event: EventModel,
     venueIdToPartnershipMap: Map<string, PartnerModel[]>,
@@ -639,22 +696,32 @@ export class EventsService {
     verifiedOnly: boolean,
     startDate?: Date,
     endDate?: Date,
-  ): string {
+  ): { whereClause: string; replacements: Record<string, unknown> } {
+    const replacements: Record<string, unknown> = {};
+
     const tagClause = isNotNullOrUndefined(tagClauseParams)
       ? `:tagFilter && events.tags`
       : null;
 
-    const categoryClause = isNotNullOrUndefined(category)
-      ? `events.category = '${category}'`
-      : null;
+    let categoryClause: Nullable<string> = null;
+    if (isNotNullOrUndefined(category)) {
+      replacements.category = category;
+      categoryClause = `events.category = :category`;
+    }
 
     const partnerIdsArray = ensureEmbedQueryStringIsArray(owningPartnerIds);
-    const partnerIdsClause =
-      partnerIdsArray.length > 0
-        ? `events.owning_partner_id IN (${partnerIdsArray
-            .map((id) => `'${id}'`)
-            .join(', ')})`
-        : null;
+    let partnerIdsClause: Nullable<string> = null;
+    if (partnerIdsArray.length > 0) {
+      replacements.filterPartnerIdsOwning = partnerIdsArray;
+      replacements.filterPartnerIdsVenue = partnerIdsArray;
+      partnerIdsClause = `(events.owning_partner_id IN (:filterPartnerIdsOwning)
+           OR EXISTS (
+             SELECT 1 FROM datetime_venue dv2
+             JOIN venues_partners_mappings vpm ON vpm.venue_id = dv2.venue_id
+             WHERE dv2.event_id = events.id
+             AND vpm.partner_id IN (:filterPartnerIdsVenue)
+           ))`;
+    }
 
     const verifiedOnlyClause = verifiedOnly ? 'verified = true' : null;
 
@@ -672,18 +739,31 @@ export class EventsService {
     ].filter((clause) => isNotNullOrUndefined(clause));
 
     if (clauses.length === 0) {
-      return '';
-    } else {
-      return `WHERE ${clauses.join(' AND ')}`;
+      return { whereClause: '', replacements };
     }
+
+    return {
+      whereClause: `WHERE ${clauses.join(' AND ')}`,
+      replacements,
+    };
   }
 
   private async getEventCountWithFilters(
-    tagClauseParams: string,
+    tagClauseParams: Nullable<string>,
     whereClause: string,
+    whereClauseReplacements: Record<string, unknown>,
     startDate?: Date,
     endDate?: Date,
   ): Promise<number> {
+    const replacements: Record<string, unknown> = {
+      ...whereClauseReplacements,
+      startDate,
+      endDate,
+    };
+    if (isNotNullOrUndefined(tagClauseParams)) {
+      replacements.tagFilter = tagClauseParams;
+    }
+
     const results: { count: string }[] = await this.sequelize.query(
       `
       with compressed_event as (
@@ -701,11 +781,7 @@ export class EventsService {
       `,
       {
         type: QueryTypes.SELECT,
-        replacements: {
-          tagFilter: tagClauseParams,
-          startDate,
-          endDate,
-        },
+        replacements,
       },
     );
 

--- a/api-server/src/events/events.service.ts
+++ b/api-server/src/events/events.service.ts
@@ -97,7 +97,10 @@ export class EventsService {
     });
 
     if (event) {
-      await this.populateVenuePartners([event]);
+      this.populateVenuePartnersForSingleEvent(
+        event,
+        await this.buildVenuePartnerMap([event]),
+      );
     }
 
     return event;
@@ -128,7 +131,10 @@ export class EventsService {
 
     const results = await this.eventModel.findAll(mergedOptions);
 
-    await this.populateVenuePartners(results);
+    this.populateVenuePartners(
+      results,
+      await this.buildVenuePartnerMap(results),
+    );
 
     return results;
   }
@@ -242,14 +248,19 @@ export class EventsService {
             })
           : [];
 
-      // Derive venues and populate venue partners before the ownership check
-      // so that venue-partner associations are available when isOwner runs
+      // this will fetch all partnerships referenced on a venue and build a map of venue to partnership
+      const venueIdToPartnershipMap = await this.buildVenuePartnerMap(
+        paginatedRows,
+      );
+
       paginatedRows.forEach((event) => {
+        // populate date_times field on the event
         const dateTimesForEvent = dateTimes.filter(
           ({ event_id }) => event_id === event.id,
         );
         event.date_times = dateTimesForEvent;
 
+        // populate venues field on the event
         const uniqueVenues = new Map<string, VenueModel>();
         dateTimesForEvent.forEach((dt) => {
           if (dt.venue && !uniqueVenues.has(dt.venue.id)) {
@@ -257,11 +268,14 @@ export class EventsService {
           }
         });
         event.venues = [...uniqueVenues.values()];
-      });
 
-      await this.populateVenuePartners(paginatedRows);
+        // fills in via side effect partners on the associated venues,
+        // this must be done before we apply the isOwner check
+        this.populateVenuePartnersForSingleEvent(
+          event,
+          venueIdToPartnershipMap,
+        );
 
-      paginatedRows.forEach((event) => {
         // Find and assign the corresponding partner
         const partnerForEvent = event.owning_partner_id
           ? partners.find(({ id }) => id === event.owning_partner_id)
@@ -527,9 +541,36 @@ export class EventsService {
     }
   }
 
+  // Warning: This works via side-effect, setting the partners array on even venues
+  private populateVenuePartners(
+    events: EventModel[],
+    venueIdToPartnershipMap: Map<string, PartnerModel[]>,
+  ): void {
+    events.forEach((event) => {
+      (event.venues ?? []).forEach((venue) => {
+        venue.partners = venueIdToPartnershipMap.get(venue.id) ?? [];
+      });
+    });
+  }
+
+  private populateVenuePartnersForSingleEvent(
+    event: EventModel,
+    venueIdToPartnershipMap: Map<string, PartnerModel[]>,
+  ): void {
+    return this.populateVenuePartners([event], venueIdToPartnershipMap);
+  }
+
   private async buildVenuePartnerMap(
-    venueIds: string[],
+    events: EventModel[],
   ): Promise<Map<string, PartnerModel[]>> {
+    const venueIds = [
+      ...new Set(
+        events
+          .flatMap(({ venues }) => (venues ?? []).map(({ id }) => id))
+          .filter(isNotNullOrUndefined),
+      ),
+    ];
+
     if (venueIds.length === 0) {
       return new Map();
     }
@@ -569,24 +610,6 @@ export class EventsService {
     });
 
     return venueMap;
-  }
-
-  private async populateVenuePartners(events: EventModel[]): Promise<void> {
-    const venueIds = [
-      ...new Set(
-        events
-          .flatMap(({ venues }) => (venues ?? []).map(({ id }) => id))
-          .filter(isNotNullOrUndefined),
-      ),
-    ];
-
-    const venueMap = await this.buildVenuePartnerMap(venueIds);
-
-    events.forEach((event) => {
-      (event.venues ?? []).forEach((venue) => {
-        venue.partners = venueMap.get(venue.id) ?? [];
-      });
-    });
   }
 
   private getTagsClauseParams(tags: string[] | string): Nullable<string> {

--- a/api-server/src/events/models/event.model.ts
+++ b/api-server/src/events/models/event.model.ts
@@ -33,6 +33,8 @@ export class EventModel extends Model<EventModel> {
   @ApiProperty({ example: '166ab8f0-a067-11ea-aa51-cdc3fe7afefa' })
   id: string;
 
+  // this should be removed, it is no longer used (but we should make sure
+  // we don't need it for historical data first)
   @Column
   @ApiProperty({ example: 'f467e7a0-a066-11ea-aa51-cdc3fe7afefa' })
   @ForeignKey(() => VenueModel)

--- a/api-server/src/users/models/partner.model.ts
+++ b/api-server/src/users/models/partner.model.ts
@@ -10,6 +10,7 @@ import {
 import { ApiProperty } from '@nestjs/swagger';
 import { UserModel } from './user.model';
 import { EventModel } from '../../events/models/event.model';
+import { VenueModel } from '../../venues/models/venue.model';
 
 const SAMPLE_DATE = new Date();
 
@@ -54,6 +55,14 @@ export class PartnerModel extends Model<PartnerModel> {
     as: 'users',
   })
   users: UserModel[];
+
+  @BelongsToMany(() => VenueModel, {
+    through: 'venues_partners_mappings',
+    foreignKey: 'partner_id',
+    otherKey: 'venue_id',
+    as: 'venues',
+  })
+  venues: VenueModel[];
 
   // One-to-many association with events
   @HasMany(() => EventModel, {

--- a/api-server/src/venues/dto/associate-venue-partner-request.ts
+++ b/api-server/src/venues/dto/associate-venue-partner-request.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class AssociateVenuePartnerRequest {
+  @ApiProperty({
+    description: 'UUID of the venue to associate with the partner',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  venue_id: string;
+
+  @ApiProperty({
+    description: 'UUID of the partner to associate with the venue',
+    example: '987fcdeb-51a2-43d1-b456-426614174000',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  partner_id: string;
+}

--- a/api-server/src/venues/dto/single-venue-response.ts
+++ b/api-server/src/venues/dto/single-venue-response.ts
@@ -1,9 +1,9 @@
 import { ResponseWrapper } from '../../dto/response-wrapper';
 import isNotNullOrUndefined from '../../utils/is-not-null-or-undefined';
-import { VenueModel } from '../models/venue.model';
+import { VenueDTO } from './venue-dto';
 
 export class SingleVenueResponse extends ResponseWrapper {
-  venue: VenueModel;
+  venue: VenueDTO;
 
   constructor(copy?: Partial<SingleVenueResponse>) {
     super(copy);

--- a/api-server/src/venues/dto/venue-dto.ts
+++ b/api-server/src/venues/dto/venue-dto.ts
@@ -1,0 +1,99 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PartnerDTO } from '../../users/dto/partner-dto';
+
+const EXAMPLE_DATE = new Date();
+
+export class VenueDTO {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  id: string;
+
+  @ApiProperty({ example: "Bob Vance's Chill Bar" })
+  name: string;
+
+  @ApiProperty({ example: 'chill-bar' })
+  slug: string;
+
+  @ApiProperty({ example: '232 Paper St. Scranton, Pennsylvania' })
+  address: string;
+
+  @ApiProperty({ example: 'https://maps.google.com/maps/foo/bar' })
+  g_map_link: string;
+
+  @ApiProperty({ example: 32.7 })
+  gps_lat: number;
+
+  @ApiProperty({ example: 76.3 })
+  gps_long: number;
+
+  @ApiProperty({ example: 17.1 })
+  gps_alt: number;
+
+  @ApiProperty({ example: '232 Paper St.' })
+  street: string;
+
+  @ApiProperty({ example: 'Scranton' })
+  city: string;
+
+  @ApiProperty({ example: 'Pennsylvania' })
+  state: string;
+
+  @ApiProperty({ example: '18503' })
+  zip: string;
+
+  @ApiProperty({ example: 'Downtown' })
+  neighborhood: string;
+
+  @ApiProperty({ example: false })
+  is_soft_deleted: boolean;
+
+  @ApiProperty({ example: EXAMPLE_DATE })
+  createdAt: Date;
+
+  @ApiProperty({ example: EXAMPLE_DATE })
+  updatedAt: Date;
+
+  @ApiProperty({
+    type: () => [PartnerDTO],
+    required: false,
+    description: 'Partners associated with this venue',
+  })
+  partners: PartnerDTO[];
+
+  constructor(venue: {
+    id: string;
+    name: string;
+    slug: string;
+    address: string;
+    g_map_link: string;
+    gps_lat: number;
+    gps_long: number;
+    gps_alt: number;
+    street: string;
+    city: string;
+    state: string;
+    zip: string;
+    neighborhood: string;
+    is_soft_deleted: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    partners?: PartnerDTO[];
+  }) {
+    this.id = venue.id;
+    this.name = venue.name;
+    this.slug = venue.slug;
+    this.address = venue.address;
+    this.g_map_link = venue.g_map_link;
+    this.gps_lat = venue.gps_lat;
+    this.gps_long = venue.gps_long;
+    this.gps_alt = venue.gps_alt;
+    this.street = venue.street;
+    this.city = venue.city;
+    this.state = venue.state;
+    this.zip = venue.zip;
+    this.neighborhood = venue.neighborhood;
+    this.is_soft_deleted = venue.is_soft_deleted;
+    this.createdAt = venue.createdAt;
+    this.updatedAt = venue.updatedAt;
+    this.partners = venue.partners ?? [];
+  }
+}

--- a/api-server/src/venues/dto/venue-model-to-venue-dto.ts
+++ b/api-server/src/venues/dto/venue-model-to-venue-dto.ts
@@ -1,0 +1,37 @@
+import { VenueModel } from '../models/venue.model';
+import { VenueDTO } from './venue-dto';
+import { PartnerDTO } from '../../users/dto/partner-dto';
+
+export function venueModelToVenueDTO(venueModel: VenueModel): VenueDTO {
+  const partners = ((venueModel as any).partners ?? []).map(
+    (p) =>
+      new PartnerDTO({
+        id: p.id,
+        name: p.name,
+        light_logo_url: p.light_logo_url,
+        dark_logo_url: p.dark_logo_url,
+        createdAt: p.createdAt,
+        updatedAt: p.updatedAt,
+      }),
+  );
+
+  return new VenueDTO({
+    id: venueModel.id,
+    name: venueModel.name,
+    slug: venueModel.slug,
+    address: venueModel.address,
+    g_map_link: venueModel.g_map_link,
+    gps_lat: venueModel.gps_lat,
+    gps_long: venueModel.gps_long,
+    gps_alt: venueModel.gps_alt,
+    street: venueModel.street,
+    city: venueModel.city,
+    state: venueModel.state,
+    zip: venueModel.zip,
+    neighborhood: venueModel.neighborhood,
+    is_soft_deleted: venueModel.is_soft_deleted,
+    createdAt: venueModel.createdAt,
+    updatedAt: venueModel.updatedAt,
+    partners,
+  });
+}

--- a/api-server/src/venues/dto/venue-partners-list-response.ts
+++ b/api-server/src/venues/dto/venue-partners-list-response.ts
@@ -1,0 +1,22 @@
+import { ResponseWrapper } from '../../dto/response-wrapper';
+import cloneAttributes from '../../utils/clone-attributes';
+import { PartnerDTO } from '../../users/dto/partner-dto';
+
+export class VenuePartnersListResponse extends ResponseWrapper {
+  partners: PartnerDTO[];
+
+  constructor(partners: PartnerDTO[]) {
+    super();
+
+    cloneAttributes<VenuePartnersListResponse>(
+      {
+        partners,
+        paginated: false,
+        nextPage: null,
+        page: 0,
+        pageSize: partners.length,
+      },
+      this,
+    );
+  }
+}

--- a/api-server/src/venues/dto/venues-response.ts
+++ b/api-server/src/venues/dto/venues-response.ts
@@ -1,10 +1,10 @@
 import { ResponseWrapper } from '../../dto/response-wrapper';
 import isNotNullOrUndefined from '../../utils/is-not-null-or-undefined';
 import cloneAttributes from '../../utils/clone-attributes';
-import { VenueModel } from '../models/venue.model';
+import { VenueDTO } from './venue-dto';
 
 export class VenuesResponse extends ResponseWrapper {
-  venues: VenueModel[];
+  venues: VenueDTO[];
 
   constructor(copy?: Partial<VenuesResponse>) {
     super();

--- a/api-server/src/venues/models/venue.model.ts
+++ b/api-server/src/venues/models/venue.model.ts
@@ -1,6 +1,7 @@
-import { Column, IsUUID, Model, PrimaryKey, Table } from 'sequelize-typescript';
+import { BelongsToMany, Column, IsUUID, Model, PrimaryKey, Table } from 'sequelize-typescript';
 import { ApiProperty } from '@nestjs/swagger';
 import { Optional, Utils } from 'sequelize';
+import { PartnerModel } from '../../users/models/partner.model';
 
 const EXAMPLE_STATE = new Date();
 
@@ -75,4 +76,12 @@ export class VenueModel extends Model<VenueModel> {
   @Column
   @ApiProperty({ example: EXAMPLE_STATE })
   updatedAt: Date;
+
+  @BelongsToMany(() => PartnerModel, {
+    through: 'venues_partners_mappings',
+    foreignKey: 'venue_id',
+    otherKey: 'partner_id',
+    as: 'partners',
+  })
+  partners: PartnerModel[];
 }

--- a/api-server/src/venues/venues.authenticated.controller.ts
+++ b/api-server/src/venues/venues.authenticated.controller.ts
@@ -5,6 +5,7 @@ import {
   Delete,
   Header,
   Param,
+  Post,
   Put,
   UseGuards,
 } from '@nestjs/common';
@@ -20,6 +21,7 @@ import { SingleVenueResponse } from './dto/single-venue-response';
 import { VenuesService } from './venues.service';
 import FindByIdParams from '../dto/find-by-id-params';
 import { UpdateVenueRequest } from './dto/create-update-venue-request';
+import { AssociateVenuePartnerRequest } from './dto/associate-venue-partner-request';
 import isNullUndefinedOrEmpty from '../utils/isNullUndefinedOrEmpty';
 
 @Controller(`${VERSION_1_URI}/authenticated/venues`)
@@ -87,5 +89,61 @@ export default class VenuesAuthenticatedController {
     return this.venuesService.update(id, updatedValues).then((venue) => {
       return new SingleVenueResponse({ venue });
     });
+  }
+
+  @Post('partner-associate')
+  @ApiOperation({ summary: 'Associate a venue with a partner (admin only)' })
+  @ApiResponse({
+    status: 201,
+    description: 'Venue successfully associated with partner',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - validation failed',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Venue or partner not found',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Venue is already associated with this partner',
+  })
+  async associateVenueWithPartner(
+    @Body() request: AssociateVenuePartnerRequest,
+  ): Promise<{ status: string; message: string }> {
+    await this.venuesService.associateVenueWithPartner(request);
+
+    return {
+      status: 'success',
+      message: `Venue ${request.venue_id} successfully associated with partner ${request.partner_id}`,
+    };
+  }
+
+  @Post('partner-disassociate')
+  @ApiOperation({
+    summary: 'Remove association between a venue and a partner (admin only)',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Venue successfully disassociated from partner',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - validation failed',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Venue or partner not found, or association does not exist',
+  })
+  async disassociateVenueFromPartner(
+    @Body() request: AssociateVenuePartnerRequest,
+  ): Promise<{ status: string; message: string }> {
+    await this.venuesService.disassociateVenueFromPartner(request);
+
+    return {
+      status: 'success',
+      message: `Venue ${request.venue_id} successfully disassociated from partner ${request.partner_id}`,
+    };
   }
 }

--- a/api-server/src/venues/venues.authenticated.controller.ts
+++ b/api-server/src/venues/venues.authenticated.controller.ts
@@ -23,6 +23,7 @@ import FindByIdParams from '../dto/find-by-id-params';
 import { UpdateVenueRequest } from './dto/create-update-venue-request';
 import { AssociateVenuePartnerRequest } from './dto/associate-venue-partner-request';
 import isNullUndefinedOrEmpty from '../utils/isNullUndefinedOrEmpty';
+import { venueModelToVenueDTO } from './dto/venue-model-to-venue-dto';
 
 @Controller(`${VERSION_1_URI}/authenticated/venues`)
 @ApiTags('venues -- authenticated')
@@ -47,7 +48,7 @@ export default class VenuesAuthenticatedController {
 
     return this.venuesService
       .softDelete(id)
-      .then((venue) => new SingleVenueResponse({ venue }));
+      .then((venue) => new SingleVenueResponse({ venue: venueModelToVenueDTO(venue) }));
   }
 
   @Put('/:id/activate')
@@ -65,7 +66,7 @@ export default class VenuesAuthenticatedController {
 
     return this.venuesService
       .reactivate(id)
-      .then((venue) => new SingleVenueResponse({ venue }));
+      .then((venue) => new SingleVenueResponse({ venue: venueModelToVenueDTO(venue) }));
   }
 
   @Put('/:id')
@@ -87,7 +88,7 @@ export default class VenuesAuthenticatedController {
     const { id } = params;
 
     return this.venuesService.update(id, updatedValues).then((venue) => {
-      return new SingleVenueResponse({ venue });
+      return new SingleVenueResponse({ venue: venueModelToVenueDTO(venue) });
     });
   }
 

--- a/api-server/src/venues/venues.controller.ts
+++ b/api-server/src/venues/venues.controller.ts
@@ -14,8 +14,10 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { VERSION_1_URI } from '../utils/versionts';
 import { CreateVenueRequest } from './dto/create-update-venue-request';
 import { VenuesResponse } from './dto/venues-response';
+import { VenuePartnersListResponse } from './dto/venue-partners-list-response';
 import FindByIdParams from '../dto/find-by-id-params';
 import { SingleVenueResponse } from './dto/single-venue-response';
+import { PartnerDTO } from '../users/dto/partner-dto';
 import SlackNotificationService, {
   VENUE_SUBMIT,
 } from '../notifications/slack-notification.service';
@@ -37,6 +39,26 @@ export class VenuesController {
     private readonly slackNotificationService: SlackNotificationService,
     private readonly gpsService: GpsService,
   ) {}
+
+  @Get('/:id/partners')
+  @ApiOperation({ summary: 'get partners associated with a venue' })
+  @ApiResponse({
+    status: 200,
+    description: 'list of partners for the venue',
+    type: VenuePartnersListResponse,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Venue not found',
+  })
+  async getPartnersForVenue(
+    @Param() params: FindByIdParams,
+  ): Promise<VenuePartnersListResponse> {
+    const partners = await this.venuesService.getPartnersForVenue(params.id);
+    return new VenuePartnersListResponse(
+      partners.map((p) => new PartnerDTO(p)),
+    );
+  }
 
   @Get('/:id')
   @ApiOperation({ summary: 'get a venue by id' })

--- a/api-server/src/venues/venues.controller.ts
+++ b/api-server/src/venues/venues.controller.ts
@@ -28,6 +28,7 @@ import {
 } from './dto/GetGPSCoordinatesRequest';
 import { GpsService } from './gps.services';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { venueModelToVenueDTO } from './dto/venue-model-to-venue-dto';
 
 @Controller(`${VERSION_1_URI}/venues`)
 @ApiTags('venues')
@@ -72,7 +73,7 @@ export class VenuesController {
 
     return this.venuesService
       .findById(id)
-      .then((venue) => new SingleVenueResponse({ venue }));
+      .then((venue) => new SingleVenueResponse({ venue: venueModelToVenueDTO(venue) }));
   }
 
   @Get()
@@ -88,15 +89,15 @@ export class VenuesController {
     if (includeDeleted === 'yes') {
       return this.venuesService
         .findAll()
-        .then((venues) => new VenuesResponse({ venues }));
+        .then((venues) => new VenuesResponse({ venues: venues.map(venueModelToVenueDTO) }));
     } else if (includeDeleted === 'only') {
       return this.venuesService
         .findWhereSoftDeleted()
-        .then((venues) => new VenuesResponse({ venues }));
+        .then((venues) => new VenuesResponse({ venues: venues.map(venueModelToVenueDTO) }));
     } else {
       return this.venuesService
         .findWhereNotSoftDeleted()
-        .then((venues) => new VenuesResponse({ venues }));
+        .then((venues) => new VenuesResponse({ venues: venues.map(venueModelToVenueDTO) }));
     }
   }
 
@@ -122,7 +123,7 @@ export class VenuesController {
 
         return venue;
       })
-      .then((venue) => new SingleVenueResponse({ venue }));
+      .then((venue) => new SingleVenueResponse({ venue: venueModelToVenueDTO(venue) }));
   }
 
   @Post('/get-gps-from-address')

--- a/api-server/src/venues/venues.module.ts
+++ b/api-server/src/venues/venues.module.ts
@@ -17,5 +17,6 @@ import { UsersModules } from '../users/users.modules';
   ],
   controllers: [VenuesController, VenuesAuthenticatedController],
   providers: [VenuesService, GpsService],
+  exports: [VenuesService],
 })
 export class VenuesModule {}

--- a/api-server/src/venues/venues.module.ts
+++ b/api-server/src/venues/venues.module.ts
@@ -3,6 +3,7 @@ import { VenuesController } from './venues.controller';
 import { VenuesService } from './venues.service';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { VenueModel } from './models/venue.model';
+import { PartnerModel } from '../users/models/partner.model';
 import { NotificationsModule } from '../notifications/notifications.module';
 import VenuesAuthenticatedController from './venues.authenticated.controller';
 import { GpsService } from './gps.services';
@@ -10,7 +11,7 @@ import { UsersModules } from '../users/users.modules';
 
 @Module({
   imports: [
-    SequelizeModule.forFeature([VenueModel]),
+    SequelizeModule.forFeature([VenueModel, PartnerModel]),
     NotificationsModule,
     UsersModules,
   ],

--- a/api-server/src/venues/venues.service.ts
+++ b/api-server/src/venues/venues.service.ts
@@ -1,11 +1,19 @@
-import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import {
+  ConflictException,
+  Inject,
+  Injectable,
+  LoggerService,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { VenueModel } from './models/venue.model';
+import { PartnerModel } from '../users/models/partner.model';
 import { v4 as uuidv4 } from 'uuid';
 import {
   CreateVenueRequest,
   UpdateVenueRequest,
 } from './dto/create-update-venue-request';
+import { AssociateVenuePartnerRequest } from './dto/associate-venue-partner-request';
 import { FindOptions } from 'sequelize';
 import getSlug from '../utils/get-slug';
 import { GpsService } from './gps.services';
@@ -17,6 +25,7 @@ import { isNullOrUndefined } from '../utils';
 export class VenuesService {
   constructor(
     @InjectModel(VenueModel) private venueModel: typeof VenueModel,
+    @InjectModel(PartnerModel) private partnerModel: typeof PartnerModel,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService,
     private readonly gpsService: GpsService,
@@ -107,6 +116,94 @@ export class VenuesService {
       .then((resp: [number, VenueModel[]]) => {
         return resp[1][0];
       });
+  }
+
+  async getPartnersForVenue(venueId: string): Promise<PartnerModel[]> {
+    const venue = await this.venueModel.findByPk(venueId, {
+      include: [
+        {
+          model: PartnerModel,
+          as: 'partners',
+          through: { attributes: [] },
+        },
+      ],
+    });
+
+    if (!venue) {
+      throw new NotFoundException(`Venue with ID ${venueId} not found`);
+    }
+
+    return venue.partners;
+  }
+
+  async associateVenueWithPartner(
+    request: AssociateVenuePartnerRequest,
+  ): Promise<void> {
+    const { venue_id, partner_id } = request;
+
+    const venue = await this.venueModel.findByPk(venue_id, {
+      include: [
+        {
+          model: PartnerModel,
+          as: 'partners',
+          through: { attributes: [] },
+        },
+      ],
+    });
+
+    if (!venue) {
+      throw new NotFoundException(`Venue with ID ${venue_id} not found`);
+    }
+
+    const partner = await this.partnerModel.findByPk(partner_id);
+
+    if (!partner) {
+      throw new NotFoundException(`Partner with ID ${partner_id} not found`);
+    }
+
+    const existingAssociation = venue.partners.find((p) => p.id === partner_id);
+    if (existingAssociation) {
+      throw new ConflictException(
+        `Venue ${venue_id} is already associated with partner ${partner_id}`,
+      );
+    }
+
+    await (venue as any).addPartner(partner);
+  }
+
+  async disassociateVenueFromPartner(
+    request: AssociateVenuePartnerRequest,
+  ): Promise<void> {
+    const { venue_id, partner_id } = request;
+
+    const venue = await this.venueModel.findByPk(venue_id, {
+      include: [
+        {
+          model: PartnerModel,
+          as: 'partners',
+          through: { attributes: [] },
+        },
+      ],
+    });
+
+    if (!venue) {
+      throw new NotFoundException(`Venue with ID ${venue_id} not found`);
+    }
+
+    const partner = await this.partnerModel.findByPk(partner_id);
+
+    if (!partner) {
+      throw new NotFoundException(`Partner with ID ${partner_id} not found`);
+    }
+
+    const existingAssociation = venue.partners.find((p) => p.id === partner_id);
+    if (!existingAssociation) {
+      throw new NotFoundException(
+        `Venue ${venue_id} is not associated with partner ${partner_id}`,
+      );
+    }
+
+    await (venue as any).removePartner(partner);
   }
 
   private async fillInGPSCoordinatesIfNeededWhenPossible<

--- a/api-server/src/venues/venues.service.ts
+++ b/api-server/src/venues/venues.service.ts
@@ -31,27 +31,36 @@ export class VenuesService {
     private readonly gpsService: GpsService,
   ) {}
 
-  findById(id: string): Promise<VenueModel> {
-    const options: FindOptions = {
-      where: { id },
-    };
+  private readonly partnersInclude = {
+    model: PartnerModel,
+    as: 'partners' as const,
+    through: { attributes: [] },
+  };
 
-    return this.venueModel.findOne(options);
+  findById(id: string): Promise<VenueModel> {
+    return this.venueModel.findOne({
+      where: { id },
+      include: [this.partnersInclude],
+    });
   }
 
   findAll(): Promise<VenueModel[]> {
-    return this.venueModel.findAll();
+    return this.venueModel.findAll({
+      include: [this.partnersInclude],
+    });
   }
 
   findWhereNotSoftDeleted(): Promise<VenueModel[]> {
     return this.venueModel.findAll({
       where: { is_soft_deleted: false },
+      include: [this.partnersInclude],
     });
   }
 
   findWhereSoftDeleted(): Promise<VenueModel[]> {
     return this.venueModel.findAll({
       where: { is_soft_deleted: true },
+      include: [this.partnersInclude],
     });
   }
 
@@ -61,7 +70,9 @@ export class VenuesService {
 
     newVenue = await this.fillInGPSCoordinatesIfNeededWhenPossible(newVenue);
 
-    return this.venueModel.create({ ...newVenue, id, slug });
+    await this.venueModel.create({ ...newVenue, id, slug });
+
+    return this.findById(id);
   }
 
   async update(
@@ -76,46 +87,33 @@ export class VenuesService {
       ? { ...updatedValues, slug: getSlug(updatedValues.name) }
       : { ...updatedValues };
 
-    return this.venueModel
-      .update(values, {
-        where: { id },
-        returning: true,
-      })
-      .then((resp: [number, VenueModel[]]) => {
-        if (resp[0] === 0) {
-          return null;
-        }
+    const [affectedCount] = await this.venueModel.update(values, {
+      where: { id },
+    });
 
-        return resp[1][0];
-      });
+    if (affectedCount === 0) {
+      return null;
+    }
+
+    return this.findById(id);
   }
 
-  softDelete(id: string): Promise<VenueModel> {
-    return this.venueModel
-      .update(
-        { is_soft_deleted: true },
-        {
-          where: { id },
-          returning: true,
-        },
-      )
-      .then((resp: [number, VenueModel[]]) => {
-        return resp[1][0];
-      });
+  async softDelete(id: string): Promise<VenueModel> {
+    await this.venueModel.update(
+      { is_soft_deleted: true },
+      { where: { id } },
+    );
+
+    return this.findById(id);
   }
 
-  reactivate(id: string): Promise<VenueModel> {
-    return this.venueModel
-      .update(
-        { is_soft_deleted: false },
-        {
-          where: { id },
-          returning: true,
-        },
-      )
-      .then((resp: [number, VenueModel[]]) => {
-        return resp[1][0];
-      });
+  async reactivate(id: string): Promise<VenueModel> {
+    await this.venueModel.update(
+      { is_soft_deleted: false },
+      { where: { id } },
+    );
+
+    return this.findById(id);
   }
 
   async getPartnersForVenue(venueId: string): Promise<PartnerModel[]> {

--- a/api-server/test/current-events.e2e-spec.ts
+++ b/api-server/test/current-events.e2e-spec.ts
@@ -386,6 +386,60 @@ describe('CurrentEvents (e2e)', () => {
       });
   });
 
+  it('returns venue partners on events when venues have associated partners', async () => {
+    const futureTime = getDateTimePair(getTimePlusX(today, 1));
+    const venue = await createVenue(generateVenue(venueModel));
+
+    const venuePartner = await partnerModel.create({
+      id: faker.datatype.uuid(),
+      name: 'Venue Partner',
+      light_logo_url: 'https://example.com/venue-partner-light.png',
+      dark_logo_url: 'https://example.com/venue-partner-dark.png',
+    });
+
+    await createEvent(
+      generateEvent(eventModel, { venue_id: venue.id, verified: true }),
+      [futureTime],
+    );
+
+    await associateVenueWithPartner(venue.id, venuePartner.id);
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/events/current-verified`)
+      .expect(200)
+      .then(async (response) => {
+        expect(response.body.events.length).toEqual(1);
+
+        const event = response.body.events[0];
+        expect(event.venue).toBeDefined();
+        expect(event.venue.partners).toBeDefined();
+        expect(event.venue.partners).toHaveLength(1);
+        expect(event.venue.partners[0].id).toEqual(venuePartner.id);
+        expect(event.venue.partners[0].name).toEqual(venuePartner.name);
+      });
+  });
+
+  it('returns empty partners array on venue when venue has no associated partners', async () => {
+    const futureTime = getDateTimePair(getTimePlusX(today, 1));
+    const venue = await createVenue(generateVenue(venueModel));
+
+    await createEvent(
+      generateEvent(eventModel, { venue_id: venue.id, verified: true }),
+      [futureTime],
+    );
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/events/current-verified`)
+      .expect(200)
+      .then(async (response) => {
+        expect(response.body.events.length).toEqual(1);
+
+        const event = response.body.events[0];
+        expect(event.venue).toBeDefined();
+        expect(event.venue.partners).toEqual([]);
+      });
+  });
+
   function getTimePlusX(time, deltaHours) {
     const incrementedTime = new Date(time);
     incrementedTime.setHours(incrementedTime.getHours() + deltaHours);
@@ -462,5 +516,15 @@ describe('CurrentEvents (e2e)', () => {
 
   async function deleteAllPartners() {
     await partnerModel.destroy({ where: {} });
+  }
+
+  async function associateVenueWithPartner(
+    venueId: string,
+    partnerId: string,
+  ): Promise<void> {
+    const venue = await venueModel.findByPk(venueId);
+    const partner = await partnerModel.findByPk(partnerId);
+
+    await (venue as any).addPartner(partner);
   }
 });

--- a/api-server/test/events.authenticated.e2e-spec.ts
+++ b/api-server/test/events.authenticated.e2e-spec.ts
@@ -1300,6 +1300,133 @@ describe('Authenticated Events API', () => {
           );
         });
     });
+
+    it('should include non-verified events matched via venue-partner association', async () => {
+      const partner = await createPartner({
+        name: 'Venue Partner',
+        light_logo_url: 'https://example.com/venue-partner-light.png',
+        dark_logo_url: 'https://example.com/venue-partner-dark.png',
+      });
+
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200);
+
+      const userId = userResponse.body.id;
+      await associateUserWithPartners(userId, [partner.id]);
+
+      // Event with direct owning_partner_id
+      const directEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: false, owning_partner_id: partner.id },
+      );
+
+      // Event with NO owning_partner_id, but its venue is associated with the partner
+      const venueEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: false },
+      );
+      await associateVenueWithPartner(
+        venueEvent.date_times[0].venue_id,
+        partner.id,
+      );
+
+      // Unrelated event (should be excluded)
+      await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: false },
+      );
+
+      // Verified event at partner venue (should be excluded -- endpoint is non-verified only)
+      const verifiedVenueEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: true },
+      );
+      await associateVenueWithPartner(
+        verifiedVenueEvent.date_times[0].venue_id,
+        partner.id,
+      );
+
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events/non-verified-for-partners`,
+        )
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(({ body }) => {
+          const { status, events } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(2);
+
+          const returnedEventIds = events.map((e: any) => e.id);
+          expect(returnedEventIds).toContain(directEvent.id);
+          expect(returnedEventIds).toContain(venueEvent.id);
+        });
+    });
+
+    it('should not include events whose venue belongs to a different partner', async () => {
+      const userPartner = await createPartner({
+        name: 'User Partner',
+        light_logo_url: 'https://example.com/user-partner-light.png',
+        dark_logo_url: 'https://example.com/user-partner-dark.png',
+      });
+
+      const otherPartner = await createPartner({
+        name: 'Other Partner',
+        light_logo_url: 'https://example.com/other-partner-light.png',
+        dark_logo_url: 'https://example.com/other-partner-dark.png',
+      });
+
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200);
+
+      await associateUserWithPartners(userResponse.body.id, [userPartner.id]);
+
+      // Event at a venue associated with a different partner
+      const otherVenueEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: false },
+      );
+      await associateVenueWithPartner(
+        otherVenueEvent.date_times[0].venue_id,
+        otherPartner.id,
+      );
+
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events/non-verified-for-partners`,
+        )
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(({ body }) => {
+          const { status, events } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(0);
+        });
+    });
   });
 
   // TODO: Refactor this to just include these tests alongside the endpoints they test
@@ -1960,6 +2087,346 @@ describe('Authenticated Events API', () => {
     });
   });
 
+  describe('Venue-Partner Ownership Tests', () => {
+    it('should successfully delete event when partner admin owns it via venue-partner association', async () => {
+      const venuePartner = await createPartner({
+        name: 'Venue Partner',
+        light_logo_url: 'https://example.com/venue-partner-light.png',
+        dark_logo_url: 'https://example.com/venue-partner-dark.png',
+      });
+
+      // Event has no owning_partner_id
+      const event = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: false },
+      );
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, venuePartner.id);
+
+      const partnerAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': partnerAdminToken })
+        .expect(200);
+
+      await associateUserWithPartners(userResponse.body.id, [venuePartner.id]);
+
+      return server
+        .delete(`/${CURRENT_VERSION_URI}/authenticated/events/${event.id}`)
+        .set('x-access-token', partnerAdminToken)
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.status).toEqual('success');
+          expect(body.id).toEqual(event.id);
+        });
+    });
+
+    it('should return 403 when partner admin tries to delete event whose venue belongs to a different partner', async () => {
+      const userPartner = await createPartner({
+        name: 'User Partner',
+        light_logo_url: 'https://example.com/user-partner-light.png',
+        dark_logo_url: 'https://example.com/user-partner-dark.png',
+      });
+
+      const otherPartner = await createPartner({
+        name: 'Other Venue Partner',
+        light_logo_url: 'https://example.com/other-venue-partner-light.png',
+        dark_logo_url: 'https://example.com/other-venue-partner-dark.png',
+      });
+
+      const event = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: false },
+      );
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, otherPartner.id);
+
+      const partnerAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': partnerAdminToken })
+        .expect(200);
+
+      await associateUserWithPartners(userResponse.body.id, [userPartner.id]);
+
+      return server
+        .delete(`/${CURRENT_VERSION_URI}/authenticated/events/${event.id}`)
+        .set('x-access-token', partnerAdminToken)
+        .expect(403);
+    });
+
+    it('should successfully update event when partner admin owns it via venue-partner association', async () => {
+      const venuePartner = await createPartner({
+        name: 'Venue Partner',
+        light_logo_url: 'https://example.com/venue-partner-light.png',
+        dark_logo_url: 'https://example.com/venue-partner-dark.png',
+      });
+
+      const [events] = await createListOfFutureEventsInChronologicalOrder(1, {
+        verified: false,
+      });
+      const event = events[0];
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, venuePartner.id);
+
+      const partnerAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': partnerAdminToken })
+        .expect(200);
+
+      await associateUserWithPartners(userResponse.body.id, [venuePartner.id]);
+
+      const updateData = {
+        title: 'Updated Via Venue Partner',
+        image: 'https://example.com/updated-image.jpg',
+        organizer_contact: 'updated@example.com',
+        brief_description: 'Updated via venue-partner ownership',
+        date_times: event.date_times.map((dt) => ({
+          start_time: new Date(dt.start_time).toISOString(),
+          end_time: new Date(dt.end_time).toISOString(),
+        })),
+      };
+
+      return server
+        .put(`/${CURRENT_VERSION_URI}/authenticated/events/${event.id}`)
+        .set('x-access-token', partnerAdminToken)
+        .send(updateData)
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.id).toEqual(event.id);
+          expect(body.title).toEqual(updateData.title);
+          expect(body.brief_description).toEqual(updateData.brief_description);
+        });
+    });
+
+    it('should return 403 when partner admin tries to update event whose venue belongs to a different partner', async () => {
+      const userPartner = await createPartner({
+        name: 'User Partner',
+        light_logo_url: 'https://example.com/user-partner-light.png',
+        dark_logo_url: 'https://example.com/user-partner-dark.png',
+      });
+
+      const otherPartner = await createPartner({
+        name: 'Other Venue Partner',
+        light_logo_url: 'https://example.com/other-venue-partner-light.png',
+        dark_logo_url: 'https://example.com/other-venue-partner-dark.png',
+      });
+
+      const [events] = await createListOfFutureEventsInChronologicalOrder(1, {
+        verified: false,
+      });
+      const event = events[0];
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, otherPartner.id);
+
+      const partnerAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': partnerAdminToken })
+        .expect(200);
+
+      await associateUserWithPartners(userResponse.body.id, [userPartner.id]);
+
+      const updateData = {
+        title: 'Should Not Work',
+        image: 'https://example.com/image.jpg',
+        organizer_contact: 'test@example.com',
+        brief_description: 'Should not work',
+        date_times: event.date_times.map((dt) => ({
+          start_time: new Date(dt.start_time).toISOString(),
+          end_time: new Date(dt.end_time).toISOString(),
+        })),
+      };
+
+      return server
+        .put(`/${CURRENT_VERSION_URI}/authenticated/events/${event.id}`)
+        .set('x-access-token', partnerAdminToken)
+        .send(updateData)
+        .expect(403);
+    });
+
+    it('should successfully verify event when partner admin owns it via venue-partner association', async () => {
+      const venuePartner = await createPartner({
+        name: 'Venue Partner',
+        light_logo_url: 'https://example.com/venue-partner-light.png',
+        dark_logo_url: 'https://example.com/venue-partner-dark.png',
+      });
+
+      const [events] = await createListOfFutureEventsInChronologicalOrder(1, {
+        verified: false,
+      });
+      const event = events[0];
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, venuePartner.id);
+
+      const partnerAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': partnerAdminToken })
+        .expect(200);
+
+      await associateUserWithPartners(userResponse.body.id, [venuePartner.id]);
+
+      return server
+        .put(
+          `/${CURRENT_VERSION_URI}/authenticated/events/verify/${event.id}`,
+        )
+        .set('x-access-token', partnerAdminToken)
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.verified).toEqual(true);
+          expect(body.id).toEqual(event.id);
+        });
+    });
+
+    it('should return 403 when partner admin tries to verify event whose venue belongs to a different partner', async () => {
+      const userPartner = await createPartner({
+        name: 'User Partner',
+        light_logo_url: 'https://example.com/user-partner-light.png',
+        dark_logo_url: 'https://example.com/user-partner-dark.png',
+      });
+
+      const otherPartner = await createPartner({
+        name: 'Other Venue Partner',
+        light_logo_url: 'https://example.com/other-venue-partner-light.png',
+        dark_logo_url: 'https://example.com/other-venue-partner-dark.png',
+      });
+
+      const [events] = await createListOfFutureEventsInChronologicalOrder(1, {
+        verified: false,
+      });
+      const event = events[0];
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, otherPartner.id);
+
+      const partnerAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': partnerAdminToken })
+        .expect(200);
+
+      await associateUserWithPartners(userResponse.body.id, [userPartner.id]);
+
+      return server
+        .put(
+          `/${CURRENT_VERSION_URI}/authenticated/events/verify/${event.id}`,
+        )
+        .set('x-access-token', partnerAdminToken)
+        .expect(403);
+    });
+
+    it('should successfully update admin-metadata when partner admin owns event via venue-partner association', async () => {
+      const venuePartner = await createPartner({
+        name: 'Venue Partner',
+        light_logo_url: 'https://example.com/venue-partner-light.png',
+        dark_logo_url: 'https://example.com/venue-partner-dark.png',
+      });
+
+      const [events] = await createListOfFutureEventsInChronologicalOrder(1, {
+        verified: false,
+      });
+      const event = events[0];
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, venuePartner.id);
+
+      const partnerAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': partnerAdminToken })
+        .expect(200);
+
+      await associateUserWithPartners(userResponse.body.id, [venuePartner.id]);
+
+      return server
+        .put(
+          `/${CURRENT_VERSION_URI}/authenticated/events/${event.id}/admin-metadata`,
+        )
+        .set('x-access-token', partnerAdminToken)
+        .send({ isProblem: true })
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.status).toEqual('success');
+          expect(body.eventAdminMetadata).toBeDefined();
+          expect(body.eventAdminMetadata.event_id).toEqual(event.id);
+          expect(body.eventAdminMetadata.is_problem).toEqual(true);
+        });
+    });
+
+    it('should return 403 when partner admin tries to update admin-metadata for event whose venue belongs to a different partner', async () => {
+      const userPartner = await createPartner({
+        name: 'User Partner',
+        light_logo_url: 'https://example.com/user-partner-light.png',
+        dark_logo_url: 'https://example.com/user-partner-dark.png',
+      });
+
+      const otherPartner = await createPartner({
+        name: 'Other Venue Partner',
+        light_logo_url: 'https://example.com/other-venue-partner-light.png',
+        dark_logo_url: 'https://example.com/other-venue-partner-dark.png',
+      });
+
+      const [events] = await createListOfFutureEventsInChronologicalOrder(1, {
+        verified: false,
+      });
+      const event = events[0];
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, otherPartner.id);
+
+      const partnerAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': partnerAdminToken })
+        .expect(200);
+
+      await associateUserWithPartners(userResponse.body.id, [userPartner.id]);
+
+      return server
+        .put(
+          `/${CURRENT_VERSION_URI}/authenticated/events/${event.id}/admin-metadata`,
+        )
+        .set('x-access-token', partnerAdminToken)
+        .send({ isProblem: true })
+        .expect(403);
+    });
+  });
+
   describe('Partner ID Filtering Tests', () => {
     it('/authenticated/events should filter events by single owning_partner_id', async () => {
       // Create partners
@@ -2322,6 +2789,137 @@ describe('Authenticated Events API', () => {
           partnerEventsInRange.forEach((expectedEvent) => {
             expect(returnedEventIds).toContain(expectedEvent.id);
           });
+        });
+    });
+
+    it('/authenticated/events should include events matched via venue-partner association when filtering by owning_partner_id', async () => {
+      const partner = await createPartner({
+        name: 'Venue-Associated Partner',
+        light_logo_url: 'https://example.com/venue-assoc-light.png',
+        dark_logo_url: 'https://example.com/venue-assoc-dark.png',
+      });
+
+      // Event with direct owning_partner_id
+      const directEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: true, owning_partner_id: partner.id },
+      );
+
+      // Event with NO owning_partner_id, but its venue is associated with the partner
+      const venueEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: true },
+      );
+      const venueId = venueEvent.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, partner.id);
+
+      // Unrelated event (should be excluded)
+      await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: true },
+      );
+
+      const token = await login();
+
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events?owning_partner_id=${partner.id}`,
+        )
+        .set('x-access-token', token)
+        .expect(200)
+        .then(async ({ body }) => {
+          const { events, status } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(2);
+
+          const returnedEventIds = events.map((e) => e.id);
+          expect(returnedEventIds).toContain(directEvent.id);
+          expect(returnedEventIds).toContain(venueEvent.id);
+        });
+    });
+
+    it('/authenticated/events should not duplicate events that match both owning_partner_id and venue-partner association', async () => {
+      const partner = await createPartner({
+        name: 'Dual-Match Partner',
+        light_logo_url: 'https://example.com/dual-light.png',
+        dark_logo_url: 'https://example.com/dual-dark.png',
+      });
+
+      // Event has owning_partner_id AND its venue is also associated with the same partner
+      const dualMatchEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: true, owning_partner_id: partner.id },
+      );
+      const venueId = dualMatchEvent.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, partner.id);
+
+      const token = await login();
+
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events?owning_partner_id=${partner.id}`,
+        )
+        .set('x-access-token', token)
+        .expect(200)
+        .then(async ({ body }) => {
+          const { events, status } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(1);
+          expect(events[0].id).toEqual(dualMatchEvent.id);
+        });
+    });
+
+    it('/authenticated/events should include venue-partner events in pagination count', async () => {
+      const partner = await createPartner({
+        name: 'Pagination Partner',
+        light_logo_url: 'https://example.com/pag-light.png',
+        dark_logo_url: 'https://example.com/pag-dark.png',
+      });
+
+      // 3 events with direct owning_partner_id
+      await createListOfFutureEventsInChronologicalOrder(3, {
+        verified: true,
+        owning_partner_id: partner.id,
+      });
+
+      // 2 events matched via venue-partner association only
+      for (let i = 0; i < 2; i++) {
+        const venueEvent = await createRandomEventWithDateTime(
+          eventModel,
+          venueModel,
+          datetimeVenueModel,
+          { verified: true },
+        );
+        await associateVenueWithPartner(
+          venueEvent.date_times[0].venue_id,
+          partner.id,
+        );
+      }
+
+      const token = await login();
+
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events?owning_partner_id=${partner.id}&page=1&pageSize=10`,
+        )
+        .set('x-access-token', token)
+        .expect(200)
+        .then(async ({ body }) => {
+          const { events, status, totalPages } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(5);
+          expect(totalPages).toEqual(1);
         });
     });
   });

--- a/api-server/test/events.authenticated.e2e-spec.ts
+++ b/api-server/test/events.authenticated.e2e-spec.ts
@@ -870,6 +870,70 @@ describe('Authenticated Events API', () => {
       });
   });
 
+  it('/authenticated/events/non-verified should include venue partners when venues have associated partners', async () => {
+    const partner = await createPartner({
+      name: 'Venue Partner for Non-Verified',
+      light_logo_url: 'https://example.com/venue-partner-light.png',
+      dark_logo_url: 'https://example.com/venue-partner-dark.png',
+    });
+
+    const event = await createRandomEventWithDateTime(
+      eventModel,
+      venueModel,
+      datetimeVenueModel,
+      { verified: false },
+    );
+
+    const venueId = event.date_times[0].venue_id;
+    await associateVenueWithPartner(venueId, partner.id);
+
+    const token = await login();
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/authenticated/events/non-verified`)
+      .set('x-access-token', token)
+      .expect(200)
+      .then(({ body }) => {
+        const { events, status } = body;
+
+        expect(status).toEqual('success');
+        expect(events).toHaveLength(1);
+
+        const returnedEvent = events[0];
+        expect(returnedEvent.venue).toBeDefined();
+        expect(returnedEvent.venue.partners).toBeDefined();
+        expect(returnedEvent.venue.partners).toHaveLength(1);
+        expect(returnedEvent.venue.partners[0].id).toEqual(partner.id);
+        expect(returnedEvent.venue.partners[0].name).toEqual(partner.name);
+      });
+  });
+
+  it('/authenticated/events/non-verified should return empty partners array on venue when venue has no associated partners', async () => {
+    await createRandomEventWithDateTime(
+      eventModel,
+      venueModel,
+      datetimeVenueModel,
+      { verified: false },
+    );
+
+    const token = await login();
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/authenticated/events/non-verified`)
+      .set('x-access-token', token)
+      .expect(200)
+      .then(({ body }) => {
+        const { events, status } = body;
+
+        expect(status).toEqual('success');
+        expect(events).toHaveLength(1);
+
+        const returnedEvent = events[0];
+        expect(returnedEvent.venue).toBeDefined();
+        expect(returnedEvent.venue.partners).toEqual([]);
+      });
+  });
+
   it('should successfully delete event when infinite admin accesses it', async () => {
     // Create an event
     const [events] = await createListOfFutureEventsInChronologicalOrder(1, {
@@ -1173,6 +1237,67 @@ describe('Authenticated Events API', () => {
           expect(eventIds).toContain(partner1Event.id);
           expect(eventIds).toContain(partner2Event.id);
           expect(eventIds).toContain(noPartnerEvent.id);
+        });
+    });
+
+    it('should include venue partners on returned events when venues have associated partners', async () => {
+      const owningPartner = await createPartner({
+        name: 'Owning Partner',
+        light_logo_url: 'https://example.com/owning-partner-light.png',
+        dark_logo_url: 'https://example.com/owning-partner-dark.png',
+      });
+
+      const venuePartner = await createPartner({
+        name: 'Venue Partner',
+        light_logo_url: 'https://example.com/venue-partner-light.png',
+        dark_logo_url: 'https://example.com/venue-partner-dark.png',
+      });
+
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200);
+
+      const userId = userResponse.body.id;
+      await associateUserWithPartners(userId, [owningPartner.id]);
+
+      const event = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: false,
+          owning_partner_id: owningPartner.id,
+        },
+      );
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, venuePartner.id);
+
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/authenticated/events/non-verified-for-partners`,
+        )
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(({ body }) => {
+          const { status, events } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(1);
+
+          const returnedEvent = events[0];
+          expect(returnedEvent.venue).toBeDefined();
+          expect(returnedEvent.venue.partners).toBeDefined();
+          expect(returnedEvent.venue.partners).toHaveLength(1);
+          expect(returnedEvent.venue.partners[0].id).toEqual(venuePartner.id);
+          expect(returnedEvent.venue.partners[0].name).toEqual(
+            venuePartner.name,
+          );
         });
     });
   });
@@ -2248,5 +2373,15 @@ describe('Authenticated Events API', () => {
 
     // Use the association method to set partners
     await (user as any).setPartners(partners);
+  }
+
+  async function associateVenueWithPartner(
+    venueId: string,
+    partnerId: string,
+  ): Promise<void> {
+    const venue = await venueModel.findByPk(venueId);
+    const partner = await partnerModel.findByPk(partnerId);
+
+    await (venue as any).addPartner(partner);
   }
 });

--- a/api-server/test/events.e2e-spec.ts
+++ b/api-server/test/events.e2e-spec.ts
@@ -1498,6 +1498,131 @@ describe('Events API', () => {
           });
         });
     });
+
+    it('/verified should include events matched via venue-partner association when filtering by owning_partner_id', async () => {
+      const partner = await partnerModel.create({
+        id: uuidv4(),
+        name: 'Venue-Associated Partner',
+        light_logo_url: 'https://example.com/venue-assoc-light.png',
+        dark_logo_url: 'https://example.com/venue-assoc-dark.png',
+      });
+
+      // Event with direct owning_partner_id
+      const directEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: true, owning_partner_id: partner.id },
+      );
+
+      // Event with NO owning_partner_id, but its venue is associated with the partner
+      const venueEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: true },
+      );
+      const venueId = venueEvent.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, partner.id);
+
+      // Unrelated event (should be excluded)
+      await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: true },
+      );
+
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/events/verified?owning_partner_id=${partner.id}`,
+        )
+        .expect(200)
+        .then(async ({ body }) => {
+          const { events, status } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(2);
+
+          const returnedEventIds = events.map((e) => e.id);
+          expect(returnedEventIds).toContain(directEvent.id);
+          expect(returnedEventIds).toContain(venueEvent.id);
+        });
+    });
+
+    it('/verified should not duplicate events that match both owning_partner_id and venue-partner association', async () => {
+      const partner = await partnerModel.create({
+        id: uuidv4(),
+        name: 'Dual-Match Partner',
+        light_logo_url: 'https://example.com/dual-light.png',
+        dark_logo_url: 'https://example.com/dual-dark.png',
+      });
+
+      // Event has owning_partner_id AND its venue is also associated with the same partner
+      const dualMatchEvent = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        { verified: true, owning_partner_id: partner.id },
+      );
+      const venueId = dualMatchEvent.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, partner.id);
+
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/events/verified?owning_partner_id=${partner.id}`,
+        )
+        .expect(200)
+        .then(async ({ body }) => {
+          const { events, status } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(1);
+          expect(events[0].id).toEqual(dualMatchEvent.id);
+        });
+    });
+
+    it('/verified should include venue-partner events in pagination count', async () => {
+      const partner = await partnerModel.create({
+        id: uuidv4(),
+        name: 'Pagination Partner',
+        light_logo_url: 'https://example.com/pag-light.png',
+        dark_logo_url: 'https://example.com/pag-dark.png',
+      });
+
+      // 3 events with direct owning_partner_id
+      await createListOfFutureEventsInChronologicalOrder(3, {
+        verified: true,
+        owning_partner_id: partner.id,
+      });
+
+      // 2 events matched via venue-partner association only
+      for (let i = 0; i < 2; i++) {
+        const venueEvent = await createRandomEventWithDateTime(
+          eventModel,
+          venueModel,
+          datetimeVenueModel,
+          { verified: true },
+        );
+        await associateVenueWithPartner(
+          venueEvent.date_times[0].venue_id,
+          partner.id,
+        );
+      }
+
+      return server
+        .get(
+          `/${CURRENT_VERSION_URI}/events/verified?owning_partner_id=${partner.id}&page=1&pageSize=10`,
+        )
+        .expect(200)
+        .then(async ({ body }) => {
+          const { events, status, totalPages } = body;
+
+          expect(status).toEqual('success');
+          expect(events).toHaveLength(5);
+          expect(totalPages).toEqual(1);
+        });
+    });
   });
 
   describe('Organizer Contact Filtering Tests', () => {
@@ -1730,6 +1855,159 @@ describe('Events API', () => {
 
           expect(status).toEqual('success');
           // Partner admin should NOT see organizer_contact for events they don't own
+          expect(eventReturned.organizer_contact).toBeUndefined();
+        });
+    });
+  });
+
+  describe('Venue-Partner Ownership Tests', () => {
+    it('/events/verified should show organizer_contact for partner admin when ownership is via venue-partner association', async () => {
+      const venuePartner = await partnerModel.create({
+        id: uuidv4(),
+        name: 'Venue Partner',
+        light_logo_url: 'https://example.com/venue-partner-light.png',
+        dark_logo_url: 'https://example.com/venue-partner-dark.png',
+      });
+
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200);
+
+      const userId = userResponse.body.id;
+      await associateUserWithPartners(userId, [venuePartner.id]);
+
+      // Event has NO owning_partner_id, but its venue is associated with the user's partner
+      const event = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: true,
+          organizer_contact: 'venue-owned@example.com',
+        },
+      );
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, venuePartner.id);
+
+      return server
+        .get(`/${CURRENT_VERSION_URI}/events/verified?page=1&pageSize=10`)
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(async ({ body }) => {
+          const { events, status } = body;
+
+          expect(status).toEqual('success');
+
+          const returnedEvent = events.find((e) => e.id === event.id);
+          expect(returnedEvent).toBeDefined();
+          expect(returnedEvent.organizer_contact).toEqual(
+            'venue-owned@example.com',
+          );
+        });
+    });
+
+    it('/events/{id} should show organizer_contact for partner admin when ownership is via venue-partner association', async () => {
+      const venuePartner = await partnerModel.create({
+        id: uuidv4(),
+        name: 'Venue Partner',
+        light_logo_url: 'https://example.com/venue-partner-light.png',
+        dark_logo_url: 'https://example.com/venue-partner-dark.png',
+      });
+
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200);
+
+      const userId = userResponse.body.id;
+      await associateUserWithPartners(userId, [venuePartner.id]);
+
+      const event = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: true,
+          organizer_contact: 'venue-owned@example.com',
+        },
+      );
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, venuePartner.id);
+
+      return server
+        .get(`/${CURRENT_VERSION_URI}/events/${event.id}`)
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(async ({ body }) => {
+          const { event: eventReturned, status } = body;
+
+          expect(status).toEqual('success');
+          expect(eventReturned.organizer_contact).toEqual(
+            'venue-owned@example.com',
+          );
+        });
+    });
+
+    it('/events/{id} should strip organizer_contact when partner admin does not own the event via venue-partner or owning_partner_id', async () => {
+      const userPartner = await partnerModel.create({
+        id: uuidv4(),
+        name: 'User Partner',
+        light_logo_url: 'https://example.com/user-partner-light.png',
+        dark_logo_url: 'https://example.com/user-partner-dark.png',
+      });
+
+      const otherPartner = await partnerModel.create({
+        id: uuidv4(),
+        name: 'Other Venue Partner',
+        light_logo_url: 'https://example.com/other-venue-partner-light.png',
+        dark_logo_url: 'https://example.com/other-venue-partner-dark.png',
+      });
+
+      const userToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      const userResponse = await server
+        .get(`/${CURRENT_VERSION_URI}/users/current`)
+        .set({ 'x-access-token': userToken })
+        .expect(200);
+
+      const userId = userResponse.body.id;
+      await associateUserWithPartners(userId, [userPartner.id]);
+
+      // Event venue is associated with a different partner
+      const event = await createRandomEventWithDateTime(
+        eventModel,
+        venueModel,
+        datetimeVenueModel,
+        {
+          verified: true,
+          organizer_contact: 'not-yours@example.com',
+        },
+      );
+
+      const venueId = event.date_times[0].venue_id;
+      await associateVenueWithPartner(venueId, otherPartner.id);
+
+      return server
+        .get(`/${CURRENT_VERSION_URI}/events/${event.id}`)
+        .set({ 'x-access-token': userToken })
+        .expect(200)
+        .then(async ({ body }) => {
+          const { event: eventReturned, status } = body;
+
+          expect(status).toEqual('success');
           expect(eventReturned.organizer_contact).toBeUndefined();
         });
     });

--- a/api-server/test/events.e2e-spec.ts
+++ b/api-server/test/events.e2e-spec.ts
@@ -1001,6 +1001,91 @@ describe('Events API', () => {
       });
   });
 
+  it('/events/current-verified should include venue partners when venues have associated partners', async () => {
+    const venuePartner = await partnerModel.create({
+      id: uuidv4(),
+      name: 'Venue Partner for Current Verified',
+      light_logo_url: 'https://example.com/venue-partner-light.png',
+      dark_logo_url: 'https://example.com/venue-partner-dark.png',
+    });
+
+    const futureStart = new Date();
+    futureStart.setDate(futureStart.getDate() + 1);
+    const futureEnd = new Date();
+    futureEnd.setDate(futureEnd.getDate() + 2);
+
+    const event = await createRandomEventWithDateTime(
+      eventModel,
+      venueModel,
+      datetimeVenueModel,
+      { verified: true },
+      [
+        {
+          id: uuidv4(),
+          start_time: futureStart,
+          end_time: futureEnd,
+          timezone: 'UTC',
+        },
+      ],
+    );
+
+    const venueId = event.date_times[0].venue_id;
+    await associateVenueWithPartner(venueId, venuePartner.id);
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/events/current-verified`)
+      .expect(200)
+      .then(({ body }) => {
+        const { events, status } = body;
+
+        expect(status).toEqual('success');
+        expect(events).toHaveLength(1);
+
+        const returnedEvent = events[0];
+        expect(returnedEvent.venue).toBeDefined();
+        expect(returnedEvent.venue.partners).toBeDefined();
+        expect(returnedEvent.venue.partners).toHaveLength(1);
+        expect(returnedEvent.venue.partners[0].id).toEqual(venuePartner.id);
+        expect(returnedEvent.venue.partners[0].name).toEqual(venuePartner.name);
+      });
+  });
+
+  it('/events/current-verified should return empty partners array on venue when venue has no associated partners', async () => {
+    const futureStart = new Date();
+    futureStart.setDate(futureStart.getDate() + 1);
+    const futureEnd = new Date();
+    futureEnd.setDate(futureEnd.getDate() + 2);
+
+    await createRandomEventWithDateTime(
+      eventModel,
+      venueModel,
+      datetimeVenueModel,
+      { verified: true },
+      [
+        {
+          id: uuidv4(),
+          start_time: futureStart,
+          end_time: futureEnd,
+          timezone: 'UTC',
+        },
+      ],
+    );
+
+    return server
+      .get(`/${CURRENT_VERSION_URI}/events/current-verified`)
+      .expect(200)
+      .then(({ body }) => {
+        const { events, status } = body;
+
+        expect(status).toEqual('success');
+        expect(events).toHaveLength(1);
+
+        const returnedEvent = events[0];
+        expect(returnedEvent.venue).toBeDefined();
+        expect(returnedEvent.venue.partners).toEqual([]);
+      });
+  });
+
   it('/events/{eventId} should include owning_partner when event has a partner', async () => {
     // Create a partner
     const partner = await partnerModel.create({
@@ -1662,5 +1747,15 @@ describe('Events API', () => {
 
     // Use the association method to set partners
     await (user as any).setPartners(partners);
+  }
+
+  async function associateVenueWithPartner(
+    venueId: string,
+    partnerId: string,
+  ): Promise<void> {
+    const venue = await venueModel.findByPk(venueId);
+    const partner = await partnerModel.findByPk(partnerId);
+
+    await (venue as any).addPartner(partner);
   }
 });

--- a/api-server/test/venues.authenticated.e2e-spec.ts
+++ b/api-server/test/venues.authenticated.e2e-spec.ts
@@ -1,0 +1,329 @@
+import startDatabase from './test-helpers/e2e-stack/start-database';
+import runMigrations from './test-helpers/e2e-stack/run-migrations';
+import startApplication from './test-helpers/e2e-stack/start-application';
+import buildDbConnectionsForTests from './test-helpers/e2e-stack/build-db-connection-for-tests';
+import request from 'supertest';
+import { ChildProcessWithoutNullStreams } from 'child_process';
+import { StartedTestContainer } from 'testcontainers';
+import { TestingModule } from '@nestjs/testing';
+import { VenueModel } from '../src/venues/models/venue.model';
+import { PartnerModel } from '../src/users/models/partner.model';
+import killApp from './test-helpers/e2e-stack/kill-app';
+import stopDatabase from './test-helpers/e2e-stack/stop-database';
+import isNotNullOrUndefined from '../src/utils/is-not-null-or-undefined';
+import generatePartnerRequest from './fakers/partner.faker';
+import { CURRENT_VERSION_URI } from '../src/utils/versionts';
+import { v4 as uuidv4 } from 'uuid';
+import { PORT } from '../src/constants';
+import createJwtForRandomUser from './test-helpers/creaeteJwt';
+import faker from 'faker';
+import getSlug from '../src/utils/get-slug';
+
+describe('Venues Authenticated (e2e)', () => {
+  const server = request('http://localhost:' + PORT);
+
+  const ASSOCIATE_ENDPOINT = `/${CURRENT_VERSION_URI}/authenticated/venues/partner-associate`;
+  const DISASSOCIATE_ENDPOINT = `/${CURRENT_VERSION_URI}/authenticated/venues/partner-disassociate`;
+
+  let appUnderTest: ChildProcessWithoutNullStreams;
+  let dbContainer: StartedTestContainer;
+
+  let venueModel: typeof VenueModel;
+  let partnerModel: typeof PartnerModel;
+  let testingModule: TestingModule;
+
+  let dbHostPort: number;
+
+  beforeAll(async () => {
+    console.info('preparing for test suite -- Venues Authenticated');
+
+    const dbInfo = await startDatabase();
+
+    dbContainer = dbInfo.dbContainer;
+    dbHostPort = dbInfo.dbHostPort;
+
+    await runMigrations(dbHostPort);
+
+    appUnderTest = await startApplication(dbHostPort);
+
+    const databaseModels = await buildDbConnectionsForTests(dbHostPort);
+
+    venueModel = databaseModels.venueModel;
+    partnerModel = databaseModels.partnerModel;
+    testingModule = databaseModels.testingModule;
+
+    console.info('test suite ready');
+
+    return Promise.resolve();
+  }, 30000);
+
+  afterAll(async () => {
+    console.info('begin cleanup for venues authenticated');
+
+    await killApp(appUnderTest);
+
+    if (appUnderTest) {
+      appUnderTest.removeAllListeners();
+    }
+
+    await stopDatabase(dbContainer);
+
+    if (isNotNullOrUndefined(testingModule)) await testingModule.close();
+
+    console.info('done cleaning up for venues authenticated');
+    return Promise.resolve();
+  });
+
+  beforeEach(async () => {
+    await deleteAllVenuesAndPartners();
+  });
+
+  describe('POST /authenticated/venues/partner-associate', () => {
+    it('should return 403 when user is not authenticated', async () => {
+      return server
+        .post(ASSOCIATE_ENDPOINT)
+        .send({ venue_id: uuidv4(), partner_id: uuidv4() })
+        .expect(403);
+    });
+
+    it('should return 403 when user is authenticated but not admin', async () => {
+      const nonAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      return server
+        .post(ASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': nonAdminToken })
+        .send({ venue_id: uuidv4(), partner_id: uuidv4() })
+        .expect(403);
+    });
+
+    it('should return 404 when venue does not exist', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const partner = await createPartner();
+
+      return server
+        .post(ASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: uuidv4(), partner_id: partner.id })
+        .expect(404)
+        .then((response) => {
+          expect(response.body.message).toContain('Venue with ID');
+          expect(response.body.message).toContain('not found');
+        });
+    });
+
+    it('should return 404 when partner does not exist', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const venue = await createVenue();
+
+      return server
+        .post(ASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: venue.id, partner_id: uuidv4() })
+        .expect(404)
+        .then((response) => {
+          expect(response.body.message).toContain('Partner with ID');
+          expect(response.body.message).toContain('not found');
+        });
+    });
+
+    it('should successfully associate a venue with a partner', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const venue = await createVenue();
+      const partner = await createPartner();
+
+      return server
+        .post(ASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: venue.id, partner_id: partner.id })
+        .expect(201)
+        .then(async (response) => {
+          expect(response.body.status).toEqual('success');
+          expect(response.body.message).toContain('successfully associated');
+          expect(response.body.message).toContain(venue.id);
+          expect(response.body.message).toContain(partner.id);
+
+          const venueWithPartners = await venueModel.findByPk(venue.id, {
+            include: [
+              {
+                model: PartnerModel,
+                as: 'partners',
+                through: { attributes: [] },
+              },
+            ],
+          });
+
+          expect(venueWithPartners.partners).toHaveLength(1);
+          expect(venueWithPartners.partners[0].id).toEqual(partner.id);
+        });
+    });
+
+    it('should return 409 when association already exists', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const venue = await createVenue();
+      const partner = await createPartner();
+
+      await server
+        .post(ASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: venue.id, partner_id: partner.id })
+        .expect(201);
+
+      return server
+        .post(ASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: venue.id, partner_id: partner.id })
+        .expect(409)
+        .then((response) => {
+          expect(response.body.message).toContain('already associated');
+        });
+    });
+
+    it('should return 400 for invalid UUID format', async () => {
+      const adminToken = await createJwtForRandomUser();
+
+      return server
+        .post(ASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: 'invalid-uuid', partner_id: 'invalid-uuid' })
+        .expect(400);
+    });
+  });
+
+  describe('POST /authenticated/venues/partner-disassociate', () => {
+    it('should return 403 when user is not authenticated', async () => {
+      return server
+        .post(DISASSOCIATE_ENDPOINT)
+        .send({ venue_id: uuidv4(), partner_id: uuidv4() })
+        .expect(403);
+    });
+
+    it('should return 403 when user is authenticated but not admin', async () => {
+      const nonAdminToken = await createJwtForRandomUser({
+        'https://infinite.industries.com/isInfiniteAdmin': false,
+      });
+
+      return server
+        .post(DISASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': nonAdminToken })
+        .send({ venue_id: uuidv4(), partner_id: uuidv4() })
+        .expect(403);
+    });
+
+    it('should return 404 when venue does not exist', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const partner = await createPartner();
+
+      return server
+        .post(DISASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: uuidv4(), partner_id: partner.id })
+        .expect(404)
+        .then((response) => {
+          expect(response.body.message).toContain('Venue with ID');
+          expect(response.body.message).toContain('not found');
+        });
+    });
+
+    it('should return 404 when partner does not exist', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const venue = await createVenue();
+
+      return server
+        .post(DISASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: venue.id, partner_id: uuidv4() })
+        .expect(404)
+        .then((response) => {
+          expect(response.body.message).toContain('Partner with ID');
+          expect(response.body.message).toContain('not found');
+        });
+    });
+
+    it('should return 404 when association does not exist', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const venue = await createVenue();
+      const partner = await createPartner();
+
+      return server
+        .post(DISASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: venue.id, partner_id: partner.id })
+        .expect(404)
+        .then((response) => {
+          expect(response.body.message).toContain('not associated');
+        });
+    });
+
+    it('should successfully disassociate a venue from a partner', async () => {
+      const adminToken = await createJwtForRandomUser();
+      const venue = await createVenue();
+      const partner = await createPartner();
+
+      await server
+        .post(ASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: venue.id, partner_id: partner.id })
+        .expect(201);
+
+      return server
+        .post(DISASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: venue.id, partner_id: partner.id })
+        .expect(201)
+        .then(async (response) => {
+          expect(response.body.status).toEqual('success');
+          expect(response.body.message).toContain('successfully disassociated');
+
+          const venueWithPartners = await venueModel.findByPk(venue.id, {
+            include: [
+              {
+                model: PartnerModel,
+                as: 'partners',
+                through: { attributes: [] },
+              },
+            ],
+          });
+
+          expect(venueWithPartners.partners).toHaveLength(0);
+        });
+    });
+
+    it('should return 400 for invalid UUID format', async () => {
+      const adminToken = await createJwtForRandomUser();
+
+      return server
+        .post(DISASSOCIATE_ENDPOINT)
+        .set({ 'x-access-token': adminToken })
+        .send({ venue_id: 'invalid-uuid', partner_id: 'invalid-uuid' })
+        .expect(400);
+    });
+  });
+
+  function createVenue(): Promise<VenueModel> {
+    return venueModel.create({
+      id: uuidv4(),
+      name: faker.company.companyName(),
+      slug: getSlug(faker.company.companyName()),
+      address: faker.address.streetAddress(),
+      street: faker.address.streetAddress(),
+      city: faker.address.city(),
+      state: faker.address.state(),
+      zip: faker.address.zipCode(),
+      neighborhood: faker.address.county(),
+      g_map_link: faker.datatype.uuid(),
+      is_soft_deleted: false,
+    });
+  }
+
+  function createPartner(): Promise<PartnerModel> {
+    const req = generatePartnerRequest();
+    return partnerModel.create({ ...req, id: uuidv4() });
+  }
+
+  async function deleteAllVenuesAndPartners(): Promise<void> {
+    await venueModel.destroy({ where: {} });
+    await partnerModel.destroy({ where: {} });
+  }
+});

--- a/api-server/test/venues.e2e-spec.ts
+++ b/api-server/test/venues.e2e-spec.ts
@@ -10,6 +10,7 @@ import { ChildProcessWithoutNullStreams } from 'child_process';
 import { StartedTestContainer } from 'testcontainers';
 import { TestingModule } from '@nestjs/testing';
 import { VenueModel } from '../src/venues/models/venue.model';
+import { PartnerModel } from '../src/users/models/partner.model';
 import { CreateVenueRequest } from '../src/venues/dto/create-update-venue-request';
 import { v4 as uuidv4 } from 'uuid';
 import getSlug from '../src/utils/get-slug';
@@ -31,6 +32,7 @@ describe('Venues (e2e)', () => {
   let dbContainer: StartedTestContainer;
 
   let venueModel: typeof VenueModel;
+  let partnerModel: typeof PartnerModel;
   let testingModule: TestingModule;
 
   let dbHostPort: number;
@@ -50,6 +52,7 @@ describe('Venues (e2e)', () => {
     const databaseModels = await buildDbConnectionsForTests(dbHostPort);
 
     venueModel = databaseModels.venueModel;
+    partnerModel = databaseModels.partnerModel;
     testingModule = databaseModels.testingModule;
 
     console.info('test suite ready');
@@ -76,7 +79,8 @@ describe('Venues (e2e)', () => {
   });
 
   beforeEach(async () => {
-    await deleteAllAnnouncements();
+    await deleteAllVenues();
+    if (partnerModel) await partnerModel.destroy({ where: {} });
   });
 
   it('[GET]/venues should return all non-soft deleted venues given no flags are passed', async () => {
@@ -263,11 +267,76 @@ describe('Venues (e2e)', () => {
         expect(respVenue.id).toBeTruthy();
         expect(respVenue.createdAt).toBeTruthy();
         expect(respVenue.updatedAt).toBeTruthy();
+        expect(respVenue.partners).toEqual([]);
 
         assertVenuesEqualIgnoringDateStampsAndLatLong(
           respVenueWithoutId,
           expectedRespValue,
         );
+      });
+  });
+
+  it('[GET]/venues should include partners on venues that have associated partners', async () => {
+    const venue = await insertVenue(generateRandomCreateVenueRequest());
+
+    const partner = await partnerModel.create({
+      id: uuidv4(),
+      name: 'Test Partner',
+      light_logo_url: 'https://example.com/light.png',
+      dark_logo_url: 'https://example.com/dark.png',
+    });
+
+    await associateVenueWithPartner(venue.id, partner.id);
+
+    return server
+      .get(GET_ALL_VENUES_END_POINT)
+      .expect(200)
+      .then(async (response) => {
+        expect(response.body.venues).toHaveLength(1);
+
+        const returnedVenue = response.body.venues[0];
+        expect(returnedVenue.partners).toBeDefined();
+        expect(returnedVenue.partners).toHaveLength(1);
+        expect(returnedVenue.partners[0].id).toEqual(partner.id);
+        expect(returnedVenue.partners[0].name).toEqual(partner.name);
+      });
+  });
+
+  it('[GET]/venues should return empty partners array on venues with no associated partners', async () => {
+    await insertVenue(generateRandomCreateVenueRequest());
+
+    return server
+      .get(GET_ALL_VENUES_END_POINT)
+      .expect(200)
+      .then(async (response) => {
+        expect(response.body.venues).toHaveLength(1);
+
+        const returnedVenue = response.body.venues[0];
+        expect(returnedVenue.partners).toEqual([]);
+      });
+  });
+
+  it('[GET]/venues/:id should include partners on the returned venue', async () => {
+    const venue = await insertVenue(generateRandomCreateVenueRequest());
+
+    const partner = await partnerModel.create({
+      id: uuidv4(),
+      name: 'Single Venue Partner',
+      light_logo_url: 'https://example.com/light.png',
+      dark_logo_url: 'https://example.com/dark.png',
+    });
+
+    await associateVenueWithPartner(venue.id, partner.id);
+
+    return server
+      .get(`${GET_ALL_VENUES_END_POINT}/${venue.id}`)
+      .expect(200)
+      .then(async (response) => {
+        const returnedVenue = response.body.venue;
+        expect(returnedVenue.partners).toBeDefined();
+        expect(returnedVenue.partners).toHaveLength(1);
+        expect(returnedVenue.partners[0].id).toEqual(partner.id);
+        expect(returnedVenue.partners[0].name).toEqual(partner.name);
       });
   });
 
@@ -309,8 +378,18 @@ describe('Venues (e2e)', () => {
     }
   }
 
-  function deleteAllAnnouncements(): Promise<number> {
+  function deleteAllVenues(): Promise<number> {
     return venueModel.destroy({ where: {} });
+  }
+
+  async function associateVenueWithPartner(
+    venueId: string,
+    partnerId: string,
+  ): Promise<void> {
+    const venue = await venueModel.findByPk(venueId);
+    const partner = await partnerModel.findByPk(partnerId);
+
+    await (venue as any).addPartner(partner);
   }
 
   function insertVenue(

--- a/e2e-tests/e2e/partnerWorkFlowsTest.js
+++ b/e2e-tests/e2e/partnerWorkFlowsTest.js
@@ -8,7 +8,7 @@ context('Partner Work Flows', () => {
   const ADMIN_USERNAME = Cypress.env('admin_auth_username')
   const ADMIN_PASSWORD = Cypress.env('admin_auth_password')
 
-  it('Styles the submission page based on partnery query param', () => {
+  it('Styles the submission page based on partner query param', () => {
     cy.visit(`/submit-event?partner=${PARTNER_NAME}`)
     
     // Verify partner information and logo are displayed on submission page
@@ -88,8 +88,8 @@ context('Partner Work Flows', () => {
     const guid = crypto.randomUUID()
     const NON_PARTNER_EVENT_NAME = `Non-Partner Test Event-${guid}`
     
-    // Submit event without partner query parameter
-    submitEvent(NON_PARTNER_EVENT_NAME, PARTNER_ADMIN_USERNAME, PARTNER_ADMIN_PASSWORD, null)
+    // Submit event without partner query parameter, at a venue not associated with any partner
+    submitEvent(NON_PARTNER_EVENT_NAME, PARTNER_ADMIN_USERNAME, PARTNER_ADMIN_PASSWORD, null, "Mom's Friendly Robot Company")
     
     // Login as partner-admin
     cy.visitAsUser(PARTNER_ADMIN_USERNAME, PARTNER_ADMIN_PASSWORD, '/')
@@ -152,8 +152,114 @@ context('Partner Work Flows', () => {
     cy.url({ timeout: 5000 }).should('include', `partner=${PARTNER_NAME}`)
   })
 
+  it('Partner admin can verify and delete events submitted at a partner-associated venue', () => {
+    const guid = crypto.randomUUID()
+    const VENUE_EVENT_NAME = `Venue Partner Test Event-${guid}`
+    
+    // Submit event at Planet Express without partner query parameter.
+    // Planet Express is associated with the partner via venue-partner mapping,
+    // so the partner-admin should still own this event even without owning_partner_id.
+    submitEvent(VENUE_EVENT_NAME, PARTNER_ADMIN_USERNAME, PARTNER_ADMIN_PASSWORD, null, 'Planet Express')
+    
+    // Login as partner-admin
+    cy.visitAsUser(PARTNER_ADMIN_USERNAME, PARTNER_ADMIN_PASSWORD, '/')
+    
+    cy.wait(750)
+    cy.get('#hamburger').click()
+    
+    // Verify Partner Admin link exists and Admin link does not
+    cy.get('#nav-list li').contains('a', 'Partner Admin').should('exist')
+    cy.get('#nav-list li a').then(($links) => {
+      const adminLinks = Array.from($links).filter(link => link.textContent.trim() === 'Admin')
+      expect(adminLinks.length).to.equal(0)
+    })
+    
+    // Click Partner Admin link
+    cy.get('#nav-list li').contains('a', 'Partner Admin').click()
+    cy.location('pathname').should('include', 'partner-admin')
+    
+    // Verify the event appears in unverified events list
+    cy.get('.unverified-events').contains('tr', VENUE_EVENT_NAME).should('exist')
+    
+    // Click Edit on the event to navigate to edit page
+    cy.get('.unverified-events').contains('tr', VENUE_EVENT_NAME).contains('Edit').click()
+    cy.location('pathname').should('include', 'admin-event-edit')
+    
+    // Partner-admin should be able to verify because Planet Express is
+    // associated with their partner (venue-based ownership)
+    cy.get('button.btn-verify').click()
+    
+    // Should redirect back to partner-admin page
+    cy.location('pathname').should('include', 'partner-admin')
+    
+    // Verify the event is no longer in unverified events list
+    cy.get('.unverified-events').contains('tr', VENUE_EVENT_NAME).should('not.exist')
+    
+    // Verify the event is now in verified events list
+    cy.get('.verified-events').contains('tr', VENUE_EVENT_NAME).should('exist')
+    
+    // Navigate to edit page to delete the event
+    cy.get('.verified-events').contains('tr', VENUE_EVENT_NAME).contains('Edit').click()
+    cy.location('pathname').should('include', 'admin-event-edit')
+    
+    // Delete the event
+    cy.get('.edit-container button').contains('Delete').click()
+    cy.get('[role="dialog"] button').contains('Kill').click()
+    
+    // Verify event is deleted and we're redirected
+    cy.location('pathname').should('include', 'partner-admin')
+    cy.get('.verified-events').contains('tr', VENUE_EVENT_NAME).should('not.exist')
+  })
+
+  it('Partner admin cannot verify events submitted at a non-partner-associated venue', () => {
+    const guid = crypto.randomUUID()
+    const NON_PARTNER_VENUE_EVENT_NAME = `Non-Partner Venue Test Event-${guid}`
+    
+    // Submit event at Mom's Friendly Robot Company without partner query parameter.
+    // This venue is NOT associated with any partner, so the partner-admin should
+    // not have ownership.
+    submitEvent(NON_PARTNER_VENUE_EVENT_NAME, PARTNER_ADMIN_USERNAME, PARTNER_ADMIN_PASSWORD, null, "Mom's Friendly Robot Company")
+    
+    // Login as admin to find the event and get the edit URL
+    cy.visitAsUser(ADMIN_USERNAME, ADMIN_PASSWORD, '/')
+    
+    cy.wait(750)
+    cy.get('#hamburger').click()
+    cy.get('#nav-list li').contains('a', 'Admin').click()
+    cy.location('pathname').should('include', 'admin')
+    
+    // Find the event in the unverified list and click Edit
+    cy.get('.unverified-events').contains('tr', NON_PARTNER_VENUE_EVENT_NAME).contains('Edit').click()
+    cy.location('pathname').should('include', 'admin-event-edit')
+    
+    cy.location('pathname').then((editPath) => {
+      // Login as partner-admin and navigate to the edit page
+      cy.visitAsUser(PARTNER_ADMIN_USERNAME, PARTNER_ADMIN_PASSWORD, editPath)
+      
+      // Intercept the verify API request to assert on the response
+      cy.intercept('PUT', '**/authenticated/events/verify/**').as('verifyRequest')
+      
+      // Try to verify the event
+      cy.get('button.btn-verify').click()
+      
+      // The verify request should fail with 403 Forbidden
+      cy.wait('@verifyRequest').its('response.statusCode').should('eq', 403)
+      
+      // Should NOT redirect — still on the edit page
+      cy.location('pathname').should('include', 'admin-event-edit')
+      
+      // Clean up: Login as admin and delete the event
+      cy.visitAsUser(ADMIN_USERNAME, ADMIN_PASSWORD, editPath)
+      
+      cy.get('.edit-container button').contains('Delete').click()
+      cy.get('[role="dialog"] button').contains('Kill').click()
+      
+      cy.location('pathname').should('include', 'admin')
+    })
+  })
+
   // === Helper Functions ===
-  function submitEvent(eventTitle, userName, userPassword, partnerName = PARTNER_NAME) {
+  function submitEvent(eventTitle, userName, userPassword, partnerName = PARTNER_NAME, venueName = null) {
     const EVENT_EMAIL = 'partner-test@te.st'
     
     const url = partnerName ? `/submit-event?partner=${partnerName}` : '/submit-event'
@@ -186,8 +292,13 @@ context('Partner Work Flows', () => {
     cy.get('select[name=end_ampm]').select('PM')
     cy.get('.date-time-picker_new-date:not([disabled])').click()
     
-    cy.get('.venue').focus()
-    cy.get('.results-container > :first-child').click()
+    if (venueName) {
+      cy.get('.venue').type(venueName)
+      cy.get('.results-container').contains(venueName).click()
+    } else {
+      cy.get('.venue').focus()
+      cy.get('.results-container > :first-child').click()
+    }
     
     // selectFile is a custom command; see cypress/support/commands.js
     cy.get('#event-image').selectFile('fixtures/images/event_sample_image.jpg')


### PR DESCRIPTION
* Creates an association table so that we can associate partners with venues.
* Updates database entities and api dtos to include partners
* Updates methods in events.service.ts so that we include the associated partners with the venues that are fetched on events.
* Updates venue.service.ts and related controller logic to fetch the related partner models
* Replaced instances where returned VenueModel directly over the API with a new VenueDTO. This is better from a separation of concerns stand point, but more importantly it avoided some really ugly TypeScript workarounds I was being forced to do :-)
* Updated related tests

This stops short of actually changing our permissions model. I will update isOwner in a followup PR. This is just putting the necessary building blocks in place.
