### PR TITLE
Fix faulty isDirty function

### DIFF
--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -393,6 +393,12 @@
     }
   })
 
+  const createFormEvent = (event) => Object.assign({}, event, {
+    condition: event.condition ? event.condition.map(t => t) : [],
+    date_times: event.date_times ? event.date_times.map(dt => ({ ...dt })) : [],
+    tags: event.tags ? event.tags.map(t => t) : []
+  })
+
   export default {
     props: ['event_id', 'user_role', 'user_action', 'owningPartnerId'],
     // user_role --> admin, venue, regular
@@ -425,11 +431,7 @@
     },
     created: function () {
       const new_event = this.$store.getters.GetCurrentEvent
-      this.calendar_event = Object.assign({}, new_event, {
-        condition: new_event.condition ? new_event.condition.map(t => t) : [],
-        date_times: new_event.date_times.map(dt => ({ ...dt })),
-        tags: new_event.tags ? new_event.tags.map(t => t) : []
-      })
+      this.calendar_event = createFormEvent(new_event);
     },
     mounted() {
       this.doTimeAndLocationExistingEventDetection()
@@ -437,7 +439,8 @@
     methods: {
       /** @public */
       isDirty: function () {
-        return !this.isEqual(this.calendar_event, this.$store.getters.GetCurrentEvent)
+        const formattedSavedEvent = createFormEvent(this.$store.getters.GetCurrentEvent);
+        return !this.isEqual(this.calendar_event, formattedSavedEvent);
       },
       isEqual: function(x, y) {
         const ok = Object.keys, tx = typeof x, ty = typeof y;


### PR DESCRIPTION
## Bug Description
When the Submit Event form is navigated away from, the user is told they have unsaved changes and asked if they are sure. This happens on every navigation away from the submit form, even when the form is completely blank. 

## Root Cause
`isDirty` was a check intended to return `true` if there were local unsaved changes and `false` if there were not. Due to formatting applied in the `created` hook of the submit form, this function always returned true because the form version of the event was different from the server version of the event.

## Solution
Fixed by applying the same formatting to the server version of the event in the `isDirty` check so the only changes detected would be actual unsaved user changes.