### PR TITLE
Fix incorrect field in Resource Template Service, and some cleanup

### DIFF
--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -489,7 +489,7 @@
         })
           .then(() => {
             if (this.user_role === 'partner-admin') {
-                this.$router.push('/partner-admin')
+              this.$router.push('/partner-admin')
             } else {
               this.$router.push('/admin')
             }
@@ -653,16 +653,6 @@
           return false
         }
       },
-      addDate: function () {
-        this.calendar_event.additional_dates.push({ time_start: '', time_end: '', title: `Day ${this.calendar_event.additional_dates.length + 2}` })
-        this.calendar_event.multi_day = true
-      },
-      removeAdditionalDate: function (index) {
-        this.calendar_event.additional_dates.splice(index, 1)
-        if (this.calendar_event.additional_dates.length === 0) {
-          this.calendar_event.multi_day = false
-        }
-      },
       onDateTimeVenueChanged: function() {
         this.doTimeAndLocationExistingEventDetection()
       },
@@ -783,7 +773,7 @@
       },
 
       isAdminOrPartnerAdmin: function() {
-        return this.user_role === 'admin' || this.user_role === 'partner-admin' 
+        return this.user_role === 'admin' || this.user_role === 'partner-admin'
       },
 
       suggestedTags: function () {

--- a/web-portal/services/ResourceTemplateService.js
+++ b/web-portal/services/ResourceTemplateService.js
@@ -3,46 +3,29 @@
  *
  * returns a new calendar event for the submission form
  *
- * @returns {{website_link: string, image: string, venue: {createdAt: string, address: string, name: string, id: string, slug: string, updatedAt: string, g_map_link: string}, multi_day: boolean, address: string, brief_description: string, ticket_link: string, additional_dates: [], description: string, title: string, social_image: string, admission_fee: string, eventbrite_link: string, organizers: string, date_times: [], id: string, organizer_contact: string, fb_event_link: string, tags: []}}
+ * @returns {{id: string, title: string, mode: string, category: string, date_times: [], venue_id: string | null, image: string, social_image: string, admission_fee: string, brief_description: string, description: string, tags: string[], website_link: string, ticket_link: string, fb_event_link: string, eventbrite_link: string, organizer_contact: string, organizers: string, multi_day: boolean, condition: string[]}}
  */
 export function getEmptyCalendarEvent() {
   return {
     id: '',
     title: '',
-    date_times: [
-
-    ],
+    mode: 'in-person',
+    category: '',
+    date_times: [],
+    venue_id: null,
     image: '',
     social_image: '',
-    organizers: '',
     admission_fee: 'none',
-    venue: { // TODO: this may be bad
-      name: '',
-      id: '',
-      slug: '',
-      createdAt: '',
-      updatedAt: '',
-      g_map_link: '',
-      address: '',
-      street: '',
-      city: '',
-      state: '',
-      zip: '',
-      neighborhood: ''
-    },
     brief_description: '',
     description: '',
-    website_link: '',
-    eventbrite_link: '',
-    fb_event_link: '',
-    ticket_link: '',
-    organizer_contact: '',
-    multi_day: false,
-    additional_dates: [],
     tags: [],
-    category: '',
-    condition: '',
-    mode: 'in-person'
-
+    website_link: '',
+    ticket_link: '',
+    fb_event_link: '',
+    eventbrite_link: '',
+    organizer_contact: '',
+    organizers: '',
+    multi_day: false,
+    condition: [],
   }
 }

--- a/web-portal/test/SubmissionForm.spec.js
+++ b/web-portal/test/SubmissionForm.spec.js
@@ -6,11 +6,6 @@ import { getEmptyCalendarEvent } from '../services/ResourceTemplateService'
 
 vi.mock('@/services/ImageUploadService')
 
-/**
- * When submission was refactored (Nov 2021) the only test case here
- * was rendered irrelevant. Keeping this for reference for future testing
- * of this component.
- */
 describe('SubmissionForm component', () => {
   let store = null
   let wrapper = null
@@ -184,6 +179,15 @@ describe('SubmissionForm component', () => {
     expect(wrapper.vm.calendar_event.condition).toEqual(['sold-out'])
   })
 
+  it('isDirty method returns false if no edits have been made', () => {
+    expect(wrapper.vm.isDirty()).toBe(false)
+  });
+
+  it('isDirty method returns true if any fields have been changed', async () => {
+    await wrapper.find('.event-mode input[type="radio"][value="online"]').setChecked(true)
+    expect(wrapper.vm.isDirty()).toBe(true)
+  });
+
   // function getFilledOutEvent() {
   //   return {
   //     'id': '',
@@ -216,7 +220,6 @@ describe('SubmissionForm component', () => {
   //     'ticket_link': '',
   //     'organizer_contact': 'chris.wininger@gmail..com',
   //     'multi_day': false,
-  //     'additional_dates': [],
   //     'venue_id': 'c2d65c4b-dee1-4449-9337-7e2de70dd1ad',
   //     'venue_name': 'Wyman, Mosciski and Wyman'
   //   }


### PR DESCRIPTION
Follow-up to #558, where after discussion this morning I realized that the create-new-blank-event helper was also initializing the `condition` field to empty string instead of empty array (note: this field maps to a Postgres array-of-string column, and can contain the values `postponed`, `cancelled`, and `sold-out`).

This PR makes that fix, and also reorders the fields in the return value to roughly match the form itself (helpful in determining that all fields were accounted for and of the correct type), removes some that are no longer relevant, and updates the doc string.

I've also removed two methods on the `SubmissionForm` component that referenced the deprecated-and-removed field `additional_dates`, and added two test cases for the component's `isDirty` method (they're not _great_ tests, but would have helped us catch #558 earlier).