### PR TITLE
Fix submission form layout issue on small screens

### DIFF
--- a/web-portal/components/SubmissionForm.vue
+++ b/web-portal/components/SubmissionForm.vue
@@ -91,14 +91,14 @@
 
       <!-- Venue -->
       <v-row wrap>
-        <v-col col="12" sm="3">
+        <v-col cols="12" sm="3">
           <h3 class="form-label">Select a Venue<span class="required-field">*</span>:</h3>
         </v-col>
-        <v-col col="12" sm="8">
+        <v-col cols="12" sm="8">
           <venue-picker ref="venuePicker" :venues="venues" :initial_venue_id="calendar_event.venue_id" @selectVenue="selectVenue"></venue-picker>
         </v-col>
-        <v-col col="0" sm="3"></v-col>
-        <v-col col="12" sm="8">
+        <v-col cols="0" sm="3"></v-col>
+        <v-col cols="12" sm="8">
           <p style="margin: 10px 0px 10px 0px; text-align: center;">OR</p>
         </v-col>
       </v-row>


### PR DESCRIPTION
Just a quick fix for something I noticed while verifying #456 -- typo'ed prop names on the layout components around the venue picker broke the layout on screen sizes below `sm`. The props on the Vuetify grid system changed from the old version we were on to the one we upgraded to during the Nuxt 2->3 work, so I probably messed them up and didn't catch it because it looks fine on tablet- and desktop-sized screens.

Current, broken:

<img width="581" height="364" alt="current, broken form; the input field is compressed and the 'OR' is pushed to the right edge instead of wrapping" src="https://github.com/user-attachments/assets/aaea0d36-dc4f-4ae1-a3be-23d348ecf1e6" />

Fixed (with these changes):

<img width="581" height="364" alt="fixed form, with the changes in this PR; the label, input, and 'OR' text each span the full width" src="https://github.com/user-attachments/assets/9e04b42b-df9a-430a-b6d2-30a4855c474f" />
