### PR TITLE
Add new admin page: "Manage Partners" with logo upload

### DIFF
--- a/api-server/package-lock.json
+++ b/api-server/package-lock.json
@@ -45,7 +45,7 @@
         "@nestjs/testing": "^9.0.0",
         "@types/express": "^4.17.13",
         "@types/jest": "29.5.0",
-        "@types/multer": "^1.4.7",
+        "@types/multer": "^1.4.13",
         "@types/node": "^16.0.0",
         "@types/node-geocoder": "^4.2.0",
         "@types/sequelize": "^4.28.14",
@@ -3878,10 +3878,11 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/multer": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.11.tgz",
-      "integrity": "sha512-svK240gr6LVWvv3YGyhLlA+6LRRWA4mnGIU7RcNmgjBYFl6665wcXrRfxGp5tEPVHUNm5FMcmq7too9bxCwX/w==",
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express": "*"
       }

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -67,7 +67,7 @@
     "@nestjs/testing": "^9.0.0",
     "@types/express": "^4.17.13",
     "@types/jest": "29.5.0",
-    "@types/multer": "^1.4.7",
+    "@types/multer": "^1.4.13",
     "@types/node": "^16.0.0",
     "@types/node-geocoder": "^4.2.0",
     "@types/sequelize": "^4.28.14",

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -43,7 +43,7 @@
     "axios": "^0.21.1",
     "class-transformer": "^0.3.1",
     "dotenv": "^8.2.0",
-    "jsonwebtoken": "^9.0.0 ",
+    "jsonwebtoken": "^9.0.0",
     "moment": "~2.29.1",
     "moment-timezone": "~0.5.33",
     "nest-winston": "^1.9.1",
@@ -55,7 +55,7 @@
     "sequelize": "^6.32.1",
     "sequelize-cli": "^6.6.1",
     "sequelize-typescript": "^2.1.5",
-    "slack-notify": "^2.0.6 ",
+    "slack-notify": "^2.0.6",
     "swagger-ui-express": "^4.6.2",
     "uuid": "^8.3.0",
     "winston": "^3.3.3"

--- a/api-server/src/uploads/uploads.constants.ts
+++ b/api-server/src/uploads/uploads.constants.ts
@@ -2,7 +2,7 @@ import { join, resolve } from 'path';
 import mkdirp from 'mkdirp';
 
 export const PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS = resolve(
-  join(__dirname, 'static', 'event-images'),
+  join(__dirname, 'static'),
 );
 
 // Ensure the local upload directory exists, even when running from dist.

--- a/api-server/src/uploads/uploads.constants.ts
+++ b/api-server/src/uploads/uploads.constants.ts
@@ -1,0 +1,9 @@
+import { join, resolve } from 'path';
+import mkdirp from 'mkdirp';
+
+export const PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS = resolve(
+  join(__dirname, 'static', 'event-images'),
+);
+
+// Ensure the local upload directory exists, even when running from dist.
+mkdirp.sync(PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS);

--- a/api-server/src/uploads/uploads.module.ts
+++ b/api-server/src/uploads/uploads.module.ts
@@ -2,15 +2,7 @@ import { Module } from '@nestjs/common';
 import { UploadsController } from './uploads.controller';
 import { UploadsService } from './uploads.service';
 import { ServeStaticModule } from '@nestjs/serve-static';
-import { join, resolve } from 'path';
-import mkdirp from 'mkdirp';
-
-export const PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS = resolve(
-  join(__dirname, 'static', 'event-images'),
-);
-
-// in theory this should exist, but sometimes this is executed from /dist and doesn't get copied
-mkdirp.sync(PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS);
+import { PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS } from './uploads.constants';
 
 @Module({
   imports: [
@@ -23,5 +15,6 @@ mkdirp.sync(PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS);
   ],
   controllers: [UploadsController],
   providers: [UploadsService],
+  exports: [UploadsService],
 })
-export class UploadsModule {}
+export class UploadsModule { }

--- a/api-server/src/uploads/uploads.module.ts
+++ b/api-server/src/uploads/uploads.module.ts
@@ -9,7 +9,7 @@ import { PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS } from './uploads.constants';
     // static file server for serving local image uploads (you should really only use this upload strategy for local dev)
     ServeStaticModule.forRoot({
       rootPath: PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS + '/',
-      serveRoot: '/uploads/event-images',
+      serveRoot: '/uploads',
       serveStaticOptions: { index: false },
     }),
   ],

--- a/api-server/src/uploads/uploads.service.ts
+++ b/api-server/src/uploads/uploads.service.ts
@@ -120,7 +120,7 @@ export class UploadsService {
     const filepath = filename
       ? `${filename}.${IMAGE_EXTENSION}`
       : this.generateNewImageName();
-    const folder = subpath ? subpath : 'uploads';
+    const folder = subpath ? `uploads/${subpath}` : 'uploads';
     const imagePath = `${folder}/${filepath}`;
 
     try {

--- a/api-server/src/uploads/uploads.service.ts
+++ b/api-server/src/uploads/uploads.service.ts
@@ -7,7 +7,7 @@ import {
   INFINITE_API_BASE_URL,
 } from '../constants';
 import { v4 as uuid } from 'uuid';
-import { PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS } from './uploads.module';
+import { PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS } from './uploads.constants';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { isNullOrUndefined } from '../utils';
 import { S3 } from '@aws-sdk/client-s3';
@@ -43,6 +43,22 @@ export class UploadsService {
     }
   }
 
+  async saveUncompressedImage(
+    img: Express.Multer.File,
+    filename: string,
+    subpath: string,
+  ) {
+    if (isNullOrUndefined(AWS_S3_UPLOADS_BUCKET)) {
+      console.debug(
+        'using local drive to persist image uploads, this should only be used for local testing',
+      );
+
+      return this.saveToLocal(img.buffer, filename, subpath);
+    } else {
+      return this.saveToS3(img.buffer, filename);
+    }
+  }
+
   private async resizeAndCompress(
     imgFile: Express.Multer.File,
   ): Promise<Buffer> {
@@ -57,11 +73,15 @@ export class UploadsService {
     return imageInProcess.webp().toBuffer();
   }
 
-  private saveToLocal(imgBuffer: Buffer): Promise<string> {
-    const subPath = 'event-images';
+  private saveToLocal(
+    imgBuffer: Buffer,
+    filename?: string,
+    subpath?: string,
+  ): Promise<string> {
+    const subPath = subpath ? subpath : 'event-images';
 
     return new Promise((resolve, reject) => {
-      const imageName = this.generateNewImageName();
+      const imageName = filename ? filename : this.generateNewImageName();
 
       // wx flag mitigates the possibility of clobbering an existing file
       // (will error out on write)
@@ -80,22 +100,27 @@ export class UploadsService {
     });
   }
 
-  private async saveToS3(imageBuffer: Buffer): Promise<string> {
+  private async saveToS3(
+    imageBuffer: Buffer,
+    filename?: string,
+    subpath?: string,
+  ): Promise<string> {
     const s3 = new S3({ region: AWS_REGION });
-
-    const imageName = `uploads/${this.generateNewImageName()}`;
+    const filepath = filename ? filename : this.generateNewImageName();
+    const folder = subpath ? subpath : 'uploads';
+    const imagePath = `${folder}/${filepath}`;
 
     try {
       await s3.putObject({
         Body: imageBuffer,
         Bucket: AWS_S3_UPLOADS_BUCKET,
-        Key: imageName,
+        Key: imagePath,
       });
 
-      return `https://${AWS_S3_UPLOADS_BUCKET}.s3.${AWS_REGION}.amazonaws.com/${imageName}`;
+      return `https://${AWS_S3_UPLOADS_BUCKET}.s3.${AWS_REGION}.amazonaws.com/${imagePath}`;
     } catch (ex) {
       this.logger.error(
-        `failed to upload an image to S3: "${imageName}" -> bucket: "${AWS_S3_UPLOADS_BUCKET}"`,
+        `failed to upload an image to S3: "${imagePath}" -> bucket: "${AWS_S3_UPLOADS_BUCKET}"`,
       );
       throw ex;
     }

--- a/api-server/src/uploads/uploads.service.ts
+++ b/api-server/src/uploads/uploads.service.ts
@@ -55,7 +55,7 @@ export class UploadsService {
 
       return this.saveToLocal(img.buffer, filename, subpath);
     } else {
-      return this.saveToS3(img.buffer, filename);
+      return this.saveToS3(img.buffer, filename, subpath);
     }
   }
 
@@ -79,24 +79,35 @@ export class UploadsService {
     subpath?: string,
   ): Promise<string> {
     const subPath = subpath ? subpath : 'event-images';
+    const dirPath = join(PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS, subPath);
 
     return new Promise((resolve, reject) => {
-      const imageName = filename ? filename : this.generateNewImageName();
+      const imageName = filename
+        ? `${filename}.${IMAGE_EXTENSION}`
+        : this.generateNewImageName();
 
-      // wx flag mitigates the possibility of clobbering an existing file
-      // (will error out on write)
-      fs.writeFile(
-        join(PATH_TO_LOCAL_EVENT_IMAGE_UPLOADS, imageName),
-        imgBuffer,
-        { flag: 'wx' },
-        (err) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(`${INFINITE_API_BASE_URL}/uploads/${subPath}/${imageName}`);
-          }
-        },
-      );
+      // ensure the target directory exists
+      fs.mkdir(dirPath, { recursive: true }, (mkdirErr) => {
+        if (mkdirErr) {
+          return reject(mkdirErr);
+        }
+
+        // wx flag mitigates the possibility of clobbering an existing file
+        // (will error out on write)
+        const savedFilePath = `${INFINITE_API_BASE_URL}/uploads/${subPath}/${imageName}`;
+        fs.writeFile(
+          join(dirPath, imageName),
+          imgBuffer,
+          { flag: 'wx' },
+          (err) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(savedFilePath);
+            }
+          },
+        );
+      });
     });
   }
 
@@ -106,7 +117,9 @@ export class UploadsService {
     subpath?: string,
   ): Promise<string> {
     const s3 = new S3({ region: AWS_REGION });
-    const filepath = filename ? filename : this.generateNewImageName();
+    const filepath = filename
+      ? `${filename}.${IMAGE_EXTENSION}`
+      : this.generateNewImageName();
     const folder = subpath ? subpath : 'uploads';
     const imagePath = `${folder}/${filepath}`;
 

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -59,12 +59,13 @@ export class PartnersAuthenticatedController {
     const folder = `partner-${id}`;
     // Add uploaded timestamp to filename as cheap & nondestructive logo versioning
     const now = new Date();
-    const datePart = now.toLocaleDateString('en-CA'); // YYYY-MM-DD
-    const timePart = now.toLocaleTimeString('en-GB').replace(/:/g, '-'); // HH-mm-ss
+    const dateStr = now
+      .toISOString()
+      .replace(/:/g, '-')
+      .replace(/\.\d+Z/, '');
+    console.log('dateStr', dateStr);
     const filepath =
-      type === 'light'
-        ? `light-logo-${datePart}_${timePart}`
-        : `dark-logo-${datePart}_${timePart}`;
+      type === 'light' ? `light-logo-${dateStr}` : `dark-logo-${dateStr}`;
     const savedImagePath = await this.uploadsService.saveUncompressedImage(
       file,
       filepath,

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -1,7 +1,18 @@
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+  UploadedFile,
+  UseInterceptors,
+  BadRequestException,
+} from '@nestjs/common';
 import { VERSION_1_URI } from '../utils/versionts';
 import {
   ApiBearerAuth,
+  ApiConsumes,
   ApiOperation,
   ApiResponse,
   ApiTags,
@@ -12,6 +23,8 @@ import { CreatePartnerRequest } from './dto/create-partner-request';
 import { AssociateUserPartnerRequest } from './dto/associate-user-partner-request';
 import { PartnerDTO } from './dto/partner-dto';
 import { PartnersListResponse } from './dto/partners-list-response';
+import { UploadsService } from '../uploads/uploads.service';
+import { FileInterceptor } from '@nestjs/platform-express';
 
 @Controller(`${VERSION_1_URI}/authenticated/partners`)
 @UseGuards(AdminAuthGuard)
@@ -19,7 +32,46 @@ import { PartnersListResponse } from './dto/partners-list-response';
 @ApiBearerAuth()
 @ApiResponse({ status: 403, description: 'Forbidden' })
 export class PartnersAuthenticatedController {
-  constructor(private readonly partnersService: PartnersService) {}
+  constructor(
+    private readonly partnersService: PartnersService,
+    private readonly uploadsService: UploadsService,
+  ) { }
+
+  @Post(':id/logo')
+  @ApiConsumes('multipart/form-data')
+  @ApiOperation({
+    summary: 'Upload a partner logo and attach it to the partner',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Partner logo uploaded and partner updated successfully',
+    type: PartnerDTO,
+  })
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadPartnerLogo(
+    @Param('id') id: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Body('type') type: 'light' | 'dark',
+  ): Promise<PartnerDTO> {
+    if (!['light', 'dark'].includes(type)) {
+      throw new BadRequestException('type must be either "light" or "dark"');
+    }
+
+    const filepath = type === 'light' ? 'light-logo' : 'dark-logo'; // TODO: how is this done elsewhere?
+    const folder = `partner_${id}`;
+    const s3ImagePath = await this.uploadsService.saveUncompressedImage(
+      file,
+      filepath,
+      folder,
+    );
+    const partner = await this.partnersService.updatePartnerLogo(
+      id,
+      type,
+      s3ImagePath,
+    );
+
+    return new PartnerDTO(partner);
+  }
 
   @Get()
   @ApiOperation({ summary: 'Get all partners (admin only)' })

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -56,8 +56,14 @@ export class PartnersAuthenticatedController {
     if (!['light', 'dark'].includes(type)) {
       throw new BadRequestException('type must be either "light" or "dark"');
     }
-
-    const filepath = type === 'light' ? 'light-logo' : 'dark-logo'; // TODO: how is this done elsewhere?
+    const now = new Date();
+    // Add uploaded timestamp to filename as cheap & nondestructive logo versioning
+    const datePart = now.toLocaleDateString('en-CA'); // YYYY-MM-DD
+    const timePart = now.toLocaleTimeString('en-GB'); // HH:mm:ss
+    const filepath =
+      type === 'light'
+        ? `light-logo-${datePart}_${timePart}`
+        : `dark-logo-${datePart}_${timePart}`;
     const folder = `partner-${id}`;
     const savedImagePath = await this.uploadsService.saveUncompressedImage(
       file,

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -58,8 +58,8 @@ export class PartnersAuthenticatedController {
     }
 
     const filepath = type === 'light' ? 'light-logo' : 'dark-logo'; // TODO: how is this done elsewhere?
-    const folder = `partner_${id}`;
-    const s3ImagePath = await this.uploadsService.saveUncompressedImage(
+    const folder = `partner-${id}`;
+    const savedImagePath = await this.uploadsService.saveUncompressedImage(
       file,
       filepath,
       folder,
@@ -67,7 +67,7 @@ export class PartnersAuthenticatedController {
     const partner = await this.partnersService.updatePartnerLogo(
       id,
       type,
-      s3ImagePath,
+      savedImagePath,
     );
 
     return new PartnerDTO(partner);

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -56,15 +56,15 @@ export class PartnersAuthenticatedController {
     if (!['light', 'dark'].includes(type)) {
       throw new BadRequestException('type must be either "light" or "dark"');
     }
-    const now = new Date();
+    const folder = `partner-${id}`;
     // Add uploaded timestamp to filename as cheap & nondestructive logo versioning
+    const now = new Date();
     const datePart = now.toLocaleDateString('en-CA'); // YYYY-MM-DD
     const timePart = now.toLocaleTimeString('en-GB').replace(/:/g, '-'); // HH-mm-ss
     const filepath =
       type === 'light'
         ? `light-logo-${datePart}_${timePart}`
         : `dark-logo-${datePart}_${timePart}`;
-    const folder = `partner-${id}`;
     const savedImagePath = await this.uploadsService.saveUncompressedImage(
       file,
       filepath,

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -59,7 +59,7 @@ export class PartnersAuthenticatedController {
     const now = new Date();
     // Add uploaded timestamp to filename as cheap & nondestructive logo versioning
     const datePart = now.toLocaleDateString('en-CA'); // YYYY-MM-DD
-    const timePart = now.toLocaleTimeString('en-GB'); // HH:mm:ss
+    const timePart = now.toLocaleTimeString('en-GB').replace(/:/g, '-'); // HH-mm-ss
     const filepath =
       type === 'light'
         ? `light-logo-${datePart}_${timePart}`

--- a/api-server/src/users/partners.authenticated.controller.ts
+++ b/api-server/src/users/partners.authenticated.controller.ts
@@ -58,12 +58,12 @@ export class PartnersAuthenticatedController {
     }
     const folder = `partner-${id}`;
     // Add uploaded timestamp to filename as cheap & nondestructive logo versioning
+    // dateStr is supposed to be human readable timestamp, eg: 2026-06-07-10-22-30 (yyyy-mm-dd-hh-mm-ss)
     const now = new Date();
     const dateStr = now
       .toISOString()
       .replace(/:/g, '-')
       .replace(/\.\d+Z/, '');
-    console.log('dateStr', dateStr);
     const filepath =
       type === 'light' ? `light-logo-${dateStr}` : `dark-logo-${dateStr}`;
     const savedImagePath = await this.uploadsService.saveUncompressedImage(

--- a/api-server/src/users/partners.controller.ts
+++ b/api-server/src/users/partners.controller.ts
@@ -7,23 +7,7 @@ import { PartnerDTO } from './dto/partner-dto';
 @Controller(`${VERSION_1_URI}/partners`)
 @ApiTags('partners')
 export class PartnersController {
-  constructor(private readonly partnersService: PartnersService) { }
-
-  @Get()
-  @ApiOperation({
-    summary: 'Get all partners',
-    description:
-      'Retrieves all partners. This endpoint is publicly accessible and does not require authentication.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Partners retrieved successfully',
-    type: [PartnerDTO],
-  })
-  async findAll(): Promise<PartnerDTO[]> {
-    const partners = await this.partnersService.findAll();
-    return partners.map((partner) => new PartnerDTO(partner));
-  }
+  constructor(private readonly partnersService: PartnersService) {}
 
   @Get('name/:name')
   @ApiOperation({

--- a/api-server/src/users/partners.controller.ts
+++ b/api-server/src/users/partners.controller.ts
@@ -7,7 +7,23 @@ import { PartnerDTO } from './dto/partner-dto';
 @Controller(`${VERSION_1_URI}/partners`)
 @ApiTags('partners')
 export class PartnersController {
-  constructor(private readonly partnersService: PartnersService) {}
+  constructor(private readonly partnersService: PartnersService) { }
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get all partners',
+    description:
+      'Retrieves all partners. This endpoint is publicly accessible and does not require authentication.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Partners retrieved successfully',
+    type: [PartnerDTO],
+  })
+  async findAll(): Promise<PartnerDTO[]> {
+    const partners = await this.partnersService.findAll();
+    return partners.map((partner) => new PartnerDTO(partner));
+  }
 
   @Get('name/:name')
   @ApiOperation({

--- a/api-server/src/users/partners.service.ts
+++ b/api-server/src/users/partners.service.ts
@@ -49,6 +49,26 @@ export class PartnersService {
     }
   }
 
+  async updatePartnerLogo(
+    partnerId: string,
+    type: 'light' | 'dark',
+    imagePath: string,
+  ): Promise<PartnerModel> {
+    const partner = await this.partnersModel.findByPk(partnerId)
+    if (!partner) {
+      throw new NotFoundException(`Partner with ID ${partnerId} not found`)
+    }
+
+    if (type === 'light') {
+      partner.light_logo_url = imagePath
+    } else {
+      partner.dark_logo_url = imagePath
+    }
+
+    await partner.save()
+    return partner
+  }
+
   async associateUserWithPartner(
     associateRequest: AssociateUserPartnerRequest,
   ): Promise<void> {

--- a/api-server/src/users/users.modules.ts
+++ b/api-server/src/users/users.modules.ts
@@ -7,9 +7,10 @@ import { PartnerModel } from './models/partner.model';
 import { PartnersService } from './partners.service';
 import { PartnersAuthenticatedController } from './partners.authenticated.controller';
 import { PartnersController } from './partners.controller';
+import { UploadsModule } from '../uploads/uploads.module';
 
 @Module({
-  imports: [SequelizeModule.forFeature([UserModel, PartnerModel])],
+  imports: [SequelizeModule.forFeature([UserModel, PartnerModel]), UploadsModule],
   controllers: [
     UsersController,
     PartnersAuthenticatedController,
@@ -18,7 +19,7 @@ import { PartnersController } from './partners.controller';
   providers: [UsersService, PartnersService],
   exports: [UsersService, PartnersService],
 })
-export class UsersModules {}
+export class UsersModules { }
 
 // Export models for use in other modules
 export { UserModel, PartnerModel };

--- a/web-portal/components/AdminNavigation.vue
+++ b/web-portal/components/AdminNavigation.vue
@@ -9,11 +9,12 @@
     <li>
       <nuxt-link to="/admin-announcement-edit">Announcements</nuxt-link>
     </li>
-
     <li>
       <nuxt-link to="/admin-venue-edit">Venues</nuxt-link>
     </li>
-
+    <li>
+      <nuxt-link to="/admin-partner-edit">Manage Partners</nuxt-link>
+    </li>
     <AuthState v-slot="{ loggedIn }">
       <li v-if="loggedIn">
         <nuxt-link @click="onLogoutClick">Logout</nuxt-link>

--- a/web-portal/components/admin-partner-edit/PartnerCard.vue
+++ b/web-portal/components/admin-partner-edit/PartnerCard.vue
@@ -57,8 +57,8 @@
   const emit = defineEmits(['upload-logo'])
 
   const logoConfig = [
-    { type: 'light', label: 'Light Logo', key: 'lightLogoUrl', bgClass: 'img-wrapper-light' },
-    { type: 'dark', label: 'Dark Logo', key: 'darkLogoUrl', bgClass: 'img-wrapper-dark' }
+    { type: 'light', label: 'Light Logo', key: 'light_logo_url', bgClass: 'img-wrapper-light' },
+    { type: 'dark', label: 'Dark Logo', key: 'dark_logo_url', bgClass: 'img-wrapper-dark' }
   ]
 
   const logoInputs = ref({})

--- a/web-portal/components/admin-partner-edit/PartnerCard.vue
+++ b/web-portal/components/admin-partner-edit/PartnerCard.vue
@@ -1,16 +1,50 @@
 <template>
   <div class="partner-card">
     <section class="partner-info">
+      <h4>{{ partner.name }}</h4>
+
+      <!-- Partner details -->
       <div v-for="field in displayFields" :key="field.key">
         <label class="partner-label">{{ field.label }}:</label>
         <span>{{ field.value }}</span>
+      </div>
+
+      <!-- Logo & Upload Section -->
+      <div class="logo-section">
+
+        <!-- Loop thru logoConfig to render Light and Dark blocks -->
+        <div v-for="logo in logoConfig" :key="logo.type" class="logo-block">
+
+          <!-- Hidden Input triggered by upload-btn -->
+          <input
+            type="file"
+            :ref="(el) => { if (el) logoInputs[logo.type] = el }"
+            accept="image/*"
+            class="hidden-input"
+            @change="handleFileChange($event, logo.type)"
+          />
+
+          <div class="upload-row">
+            <label class="partner-label">{{ logo.label }}</label>
+            <button class="upload-btn" @click="triggerUpload(logo.type)">
+              Upload {{ logo.label }}
+            </button>
+          </div>
+
+          <div class="logo-content">
+            <div :class="['img-wrapper', logo.bgClass]">
+              <img :src="partner[logo.key] || imgPlaceholder" :alt="logo.label" class="logo-img" />
+            </div>
+          </div>
+        </div>
+
       </div>
     </section>
   </div>
 </template>
 
 <script setup>
-  import { computed } from 'vue'
+  import { ref, computed } from 'vue'
 
   const props = defineProps({
     partner: {
@@ -20,32 +54,50 @@
     }
   })
 
+  const emit = defineEmits(['upload-logo'])
+
+  const logoConfig = [
+    { type: 'light', label: 'Light Logo', key: 'lightLogoUrl', bgClass: 'img-wrapper-light' },
+    { type: 'dark', label: 'Dark Logo', key: 'darkLogoUrl', bgClass: 'img-wrapper-dark' }
+  ]
+
+  const logoInputs = ref({})
+
+  const imgPlaceholder = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCAxMDAgNjAiPjxyZWN0IHdpZHRoPSIxMDAiIGhlaWdodD0iNjAiIGZpbGw9IiNlZWVlZWUiLz48dGV4dCB4PSI1MCUiIHk9IjUwJSIgZG9taW5hbnQtYmFzZWxpbmU9Im1pZGRsZSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC1mYW1pbHk9InNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTIiIGZpbGw9IiM5OTkiPk5vIEltYWdlPC90ZXh0Pjwvc3ZnPg=='
+
   const formatDate = (dateString) => {
     if (!dateString) return ''
-
     const date = new Date(dateString)
     return date.toLocaleString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
+      month: 'short', day: 'numeric', year: 'numeric',
+      hour: 'numeric', minute: 'numeric',
     })
   }
 
   const displayFields = computed(() => [
-    { key: 'name', label: 'Name', value: props.partner.name },
     { key: 'id', label: 'ID', value: props.partner.id },
-    { key: 'createdAt', label: 'Created At', value: formatDate(props.partner.createdAt) },
-    { key: 'updatedAt', label: 'Updated At', value: formatDate(props.partner.updatedAt) }
+    { key: 'updatedAt', label: 'Updated At', value: formatDate(props.partner.updatedAt) },
   ])
+
+  // Look up the hidden input ref by dark or light and click it when "Upload"
+  const triggerUpload = (type) => {
+    logoInputs.value[type]?.click()
+  }
+
+  const handleFileChange = (event, type) => {
+    const file = event.target.files[0]
+    if (file) {
+      emit('upload-logo', { partnerId: props.partner.id, type, file })
+      event.target.value = ''
+    }
+  }
 </script>
 
 <style scoped>
+/* CSS KEPT EXACTLY AS IS TO PRESERVE OUTLINES */
 .partner-card {
   margin-bottom: 1rem;
   border: 2px solid #333;
-  /* Sketch-style outline */
   border-radius: 255px 15px 225px 15px / 15px 225px 15px 255px;
   box-shadow: 4px 4px 0px rgba(0,0,0,0.8);
   padding: 1rem;
@@ -64,5 +116,103 @@
 label.partner-label {
   font-weight: bold;
   margin-right: 0.5rem;
+}
+
+.logo-section {
+  margin-top: 1.5rem;
+  border-top: 1px dashed #aaa;
+  padding-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+
+.logo-block {
+  /* Allows blocks to grow equally to fill the row */
+  flex: 1;
+  min-width: 250px;
+}
+
+.logo-content {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.upload-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.upload-row .partner-label {
+  flex: 1 1 auto;
+  margin: 0;
+}
+
+.upload-row .upload-btn {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 420px) {
+  .upload-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .upload-row .partner-label {
+    margin-bottom: 0.5rem;
+  }
+  .upload-row .upload-btn {
+    width: 100%;
+  }
+}
+
+.img-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  width: 100%;
+}
+
+.img-wrapper-light { background-color: #f0f0f0; }
+.img-wrapper-dark  { background-color: #333; }
+
+.logo-img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.upload-btn {
+  padding: 0.5rem 1rem;
+  background-color: white;
+  border: 2px solid #333;
+  border-radius: 255px 15px 225px 15px / 15px 225px 15px 255px;
+  font-weight: bold;
+  font-size: 0.9rem;
+  transition: all 0.2s ease;
+  box-shadow: 2px 2px 0px rgba(0,0,0);
+}
+
+.upload-btn:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0px rgba(0,0,0,0.5);
+  background-color: #fafafa;
+}
+
+.upload-btn:active {
+  transform: translate(1px, 1px);
+  box-shadow: 0px 0px 0px rgba(0,0,0,0.5);
+}
+
+.hidden-input {
+  display: none;
 }
 </style>

--- a/web-portal/components/admin-partner-edit/PartnerCard.vue
+++ b/web-portal/components/admin-partner-edit/PartnerCard.vue
@@ -94,7 +94,6 @@
 </script>
 
 <style scoped>
-/* CSS KEPT EXACTLY AS IS TO PRESERVE OUTLINES */
 .partner-card {
   margin-bottom: 1rem;
   border: 2px solid #333;
@@ -128,7 +127,6 @@ label.partner-label {
 }
 
 .logo-block {
-  /* Allows blocks to grow equally to fill the row */
   flex: 1;
   min-width: 250px;
 }

--- a/web-portal/components/admin-partner-edit/PartnerCard.vue
+++ b/web-portal/components/admin-partner-edit/PartnerCard.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="partner-card">
+    <section class="partner-info">
+      <div v-for="field in displayFields" :key="field.key">
+        <label class="partner-label">{{ field.label }}:</label>
+        <span>{{ field.value }}</span>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+  import { computed } from 'vue'
+
+  const props = defineProps({
+    partner: {
+      type: Object,
+      required: false,
+      default: () => ({})
+    }
+  })
+
+  const formatDate = (dateString) => {
+    if (!dateString) return ''
+
+    const date = new Date(dateString)
+    return date.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    })
+  }
+
+  const displayFields = computed(() => [
+    { key: 'name', label: 'Name', value: props.partner.name },
+    { key: 'id', label: 'ID', value: props.partner.id },
+    { key: 'createdAt', label: 'Created At', value: formatDate(props.partner.createdAt) },
+    { key: 'updatedAt', label: 'Updated At', value: formatDate(props.partner.updatedAt) }
+  ])
+</script>
+
+<style scoped>
+.partner-card {
+  margin-bottom: 1rem;
+  border: 2px solid #333;
+  /* Sketch-style outline */
+  border-radius: 255px 15px 225px 15px / 15px 225px 15px 255px;
+  box-shadow: 4px 4px 0px rgba(0,0,0,0.8);
+  padding: 1rem;
+}
+
+.partner-info {
+  display: block;
+  width: 100%;
+  font-size: larger;
+}
+
+.partner-info > div {
+  margin-bottom: 0.5rem;
+}
+
+label.partner-label {
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+</style>

--- a/web-portal/error.vue
+++ b/web-portal/error.vue
@@ -28,6 +28,22 @@
     setup ({ error }) {
       const pageNotFound = '404 Page Not Found'
       const otherError = 'An error occurred'
+      const { user } = useUserSession()
+
+      const userRole = computed(() => {
+        if (user.value?.isPartnerAdmin) {
+          return 'partner-admin'
+        } else if (user.value?.isInfiniteAdmin) {
+          return 'admin'
+        }
+        return 'regular'
+      })
+
+      onMounted(() => {
+        if(userRole.value === 'admin') {
+          console.error('Error:', error)
+        }
+      })
 
       useHead({
         title: error.status === 404 ? pageNotFound : otherError,

--- a/web-portal/pages/admin-partner-edit/index.vue
+++ b/web-portal/pages/admin-partner-edit/index.vue
@@ -53,7 +53,7 @@
   const handleLogoUpload = async ({ partnerId, type, file }) => {
     try {
       await $apiService.uploadPartnerLogo(partnerId, type, file)
-      await store.dispatch(FETCH_PARTNERS, { apiService: $apiService })
+      await store.dispatch(FETCH_PARTNERS)
     } catch (error) {
       console.error('Failed to upload partner logo:', error)
     }
@@ -62,7 +62,7 @@
   // --- Lifecycle ---
 
   onMounted(async () => {
-    await store.dispatch(FETCH_PARTNERS, { apiService: $apiService })
+    await store.dispatch(FETCH_PARTNERS)
   })
 
   // --- Meta ---

--- a/web-portal/pages/admin-partner-edit/index.vue
+++ b/web-portal/pages/admin-partner-edit/index.vue
@@ -37,7 +37,7 @@
   // --- State & Computed ---
 
   const isLoadingUser = computed(() => store.getters.GetUserDataLoading)
-  const isFetchingPartners = computed(() => store.state.partner.getPartnersQuery?.isLoading)
+  const isFetchingPartners = computed(() => store.state.partner.getPartnersQuery?.isFetching)
 
   const partners = computed(() => {
     const data = store.state.partner.getPartnersQuery?.data

--- a/web-portal/pages/admin-partner-edit/index.vue
+++ b/web-portal/pages/admin-partner-edit/index.vue
@@ -18,6 +18,7 @@
           v-for="partner in pageItems"
           :key="partner.id"
           :partner="partner"
+          @upload-logo="handleLogoUpload"
         />
       </Pagination>
     </v-app>
@@ -31,6 +32,7 @@
   import PartnerCard from '~/components/admin-partner-edit/PartnerCard.vue'
 
   const store = useStore()
+  const { $apiService } = useNuxtApp()
 
   // --- State & Computed ---
 
@@ -47,6 +49,17 @@
   })
 
   const maxNumberOfPageShortcuts = 5
+
+  const handleLogoUpload = async ({ partnerId, type, file }) => {
+    console.log(`Uploading ${type} logo for partner ${partnerId}:`, file.name)
+
+    try {
+      await $apiService.uploadPartnerLogo(partnerId, type, file)
+      await store.dispatch(FETCH_PARTNERS)
+    } catch (error) {
+      console.error('Failed to upload partner logo:', error)
+    }
+  }
 
   // --- Lifecycle ---
 

--- a/web-portal/pages/admin-partner-edit/index.vue
+++ b/web-portal/pages/admin-partner-edit/index.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="container admin-page">
+    <div v-if="isLoadingUser" class="loading-placeholder">
+      loading...
+    </div>
+
+    <v-app v-else>
+      <h1>Manage Partners</h1>
+
+      <Pagination
+        v-slot="pageItems"
+        v-show="!isFetchingPartners"
+        :items="partners"
+        :max-number-of-page-shortcuts="maxNumberOfPageShortcuts"
+        class-name-page-list="ii-admin-event-edit-page_pagination-list"
+      >
+        <partner-card
+          v-for="partner in pageItems"
+          :key="partner.id"
+          :partner="partner"
+        />
+      </Pagination>
+    </v-app>
+  </div>
+</template>
+
+<script setup>
+  import { computed, onMounted } from 'vue'
+  import { useStore } from 'vuex'
+  import { FETCH_PARTNERS } from "~/store/partner.js"
+  import PartnerCard from '~/components/admin-partner-edit/PartnerCard.vue'
+
+  const store = useStore()
+
+  // --- State & Computed ---
+
+  const isLoadingUser = computed(() => store.getters.GetUserDataLoading)
+  const isFetchingPartners = computed(() => store.state.partner.getPartnersQuery?.isLoading)
+
+  const partners = computed(() => {
+    const data = store.state.partner.getPartnersQuery?.data
+
+    if (!Array.isArray(data)) {
+      return []
+    }
+    return [...data]
+  })
+
+  const maxNumberOfPageShortcuts = 5
+
+  // --- Lifecycle ---
+
+  onMounted(async () => {
+    await store.dispatch(FETCH_PARTNERS)
+  })
+
+  // --- Meta ---
+
+  definePageMeta({
+    layout: 'admin',
+    middleware: ['auth'],
+  })
+</script>
+
+<style scoped>
+.admin-page {
+  width: 95%;
+  max-width: unset;
+}
+
+.loading-placeholder {
+  padding: 2rem;
+  text-align: center;
+  color: #666;
+}
+</style>

--- a/web-portal/pages/admin-partner-edit/index.vue
+++ b/web-portal/pages/admin-partner-edit/index.vue
@@ -51,11 +51,9 @@
   const maxNumberOfPageShortcuts = 5
 
   const handleLogoUpload = async ({ partnerId, type, file }) => {
-    console.log(`Uploading ${type} logo for partner ${partnerId}:`, file.name)
-
     try {
       await $apiService.uploadPartnerLogo(partnerId, type, file)
-      await store.dispatch(FETCH_PARTNERS)
+      await store.dispatch(FETCH_PARTNERS, { apiService: $apiService })
     } catch (error) {
       console.error('Failed to upload partner logo:', error)
     }
@@ -64,7 +62,7 @@
   // --- Lifecycle ---
 
   onMounted(async () => {
-    await store.dispatch(FETCH_PARTNERS)
+    await store.dispatch(FETCH_PARTNERS, { apiService: $apiService })
   })
 
   // --- Meta ---

--- a/web-portal/plugins/api-service-plugin.js
+++ b/web-portal/plugins/api-service-plugin.js
@@ -1,7 +1,7 @@
 
 export default defineNuxtPlugin({
   name: 'api-service',
-  async setup (nuxtApp) {
+  async setup(nuxtApp) {
     const { user } = useUserSession()
 
     return {
@@ -59,5 +59,13 @@ class ApiService {
     data.append('file', file)
 
     return this.post('/uploads/event-image', data)
+  }
+
+  uploadPartnerLogo(partnerId, type, file) {
+    const data = new FormData()
+    data.append('type', type)
+    data.append('file', file)
+
+    return this.post(`/authenticated/partners/${partnerId}/logo`, data)
   }
 }

--- a/web-portal/store/partner.js
+++ b/web-portal/store/partner.js
@@ -7,6 +7,13 @@ export const state = () => ({
   partner: null,
   // boolean
   showOnlyPartnerEvents: false,
+  // Partners list query state
+  getPartnersQuery: {
+    isFetching: false,
+    isSuccess: false,
+    error: null,
+    data: []
+  }
 })
 
 export const getters = {
@@ -15,7 +22,10 @@ export const getters = {
   },
   showOnlyPartnerEvents: (state) => {
     return state.showOnlyPartnerEvents ?? false;
-  }
+  },
+  GetActivePartners: (state) => {
+    return state.getPartnersQuery
+  },
 }
 
 export const mutations = {
@@ -25,6 +35,21 @@ export const mutations = {
   },
   SET_SHOW_ONLY_PARTNER_EVENTS: (state, payload) => {
     state.showOnlyPartnerEvents = payload && payload.toLowerCase() === "partner"
+  },
+  PARTNERS_FETCH_START(state) {
+    state.getPartnersQuery.isFetching = true;
+    state.getPartnersQuery.isSuccess = false;
+    state.getPartnersQuery.error = null;
+  },
+  PARTNERS_FETCH_SUCCESS(state, data) {
+    state.getPartnersQuery.data = Array.isArray(data) ? data : [];
+    state.getPartnersQuery.isFetching = false;
+    state.getPartnersQuery.isSuccess = true;
+  },
+  PARTNERS_FETCH_FAIL(state, error) {
+    state.getPartnersQuery.isFetching = false;
+    state.getPartnersQuery.isSuccess = false;
+    state.getPartnersQuery.error = error;
   }
 }
 
@@ -34,7 +59,7 @@ export const actions = {
     if (query.partner && query.partner !== context.state.name) {
       const { data, error } = await useAsyncData('partner-fetch', () =>
         useNuxtApp().$apiService.get(`/partners/name/${query.partner}`)
-        .catch(() => null) // eat 404s to avoid breaking everything
+          .catch(() => null) // eat 404s to avoid breaking everything
       )
 
       if (error.value) {
@@ -46,5 +71,28 @@ export const actions = {
         }
       }
     }
+  },
+  FetchPartners: function (context) {
+    context.commit('PARTNERS_FETCH_START')
+
+    return useNuxtApp().$apiService.get('/partners')
+      .then((data) => {
+        context.commit('PARTNERS_FETCH_SUCCESS', data)
+      })
+      .catch((error) => {
+        context.commit('PARTNERS_FETCH_FAIL', error)
+        // Global alert popup
+        context.commit(
+          'ui/SHOW_NOTIFICATIONS',
+          {
+            open: true,
+            message: 'Hmmm... unable to get partner data. Please contact us and we will figure out what went wrong.'
+          },
+          { root: true })
+
+        console.error(error)
+      })
   }
 }
+
+export const FETCH_PARTNERS = 'partner/FetchPartners'

--- a/web-portal/store/partner.js
+++ b/web-portal/store/partner.js
@@ -72,10 +72,17 @@ export const actions = {
       }
     }
   },
-  FetchPartners: function (context) {
+  FetchPartners: function (context, { apiService } = {}) {
     context.commit('PARTNERS_FETCH_START')
 
-    return useNuxtApp().$apiService.get('/authenticated/partners')
+    if (!apiService) {
+      const error = new Error('apiService is required to fetch partner data')
+      context.commit('PARTNERS_FETCH_FAIL', error)
+      console.error(error)
+      return Promise.reject(error)
+    }
+
+    return apiService.get('/authenticated/partners')
       .then((data) => {
         context.commit('PARTNERS_FETCH_SUCCESS', data)
       })

--- a/web-portal/store/partner.js
+++ b/web-portal/store/partner.js
@@ -72,17 +72,10 @@ export const actions = {
       }
     }
   },
-  FetchPartners: function (context, { apiService } = {}) {
+  FetchPartners: function (context) {
     context.commit('PARTNERS_FETCH_START')
 
-    if (!apiService) {
-      const error = new Error('apiService is required to fetch partner data')
-      context.commit('PARTNERS_FETCH_FAIL', error)
-      console.error(error)
-      return Promise.reject(error)
-    }
-
-    return apiService.get('/authenticated/partners')
+    return useNuxtApp().$apiService.get('/authenticated/partners')
       .then((data) => {
         context.commit('PARTNERS_FETCH_SUCCESS', data)
       })

--- a/web-portal/store/partner.js
+++ b/web-portal/store/partner.js
@@ -42,7 +42,7 @@ export const mutations = {
     state.getPartnersQuery.error = null;
   },
   PARTNERS_FETCH_SUCCESS(state, data) {
-    state.getPartnersQuery.data = Array.isArray(data) ? data : [];
+    state.getPartnersQuery.data = Array.isArray(data?.partners) ? data.partners : [];
     state.getPartnersQuery.isFetching = false;
     state.getPartnersQuery.isSuccess = true;
   },
@@ -75,7 +75,7 @@ export const actions = {
   FetchPartners: function (context) {
     context.commit('PARTNERS_FETCH_START')
 
-    return useNuxtApp().$apiService.get('/partners')
+    return useNuxtApp().$apiService.get('/authenticated/partners')
       .then((data) => {
         context.commit('PARTNERS_FETCH_SUCCESS', data)
       })


### PR DESCRIPTION
This PR adds a new page to our Admin sidebar, "Manage Partners". The main purpose of this page is to allow uploading a dark or light logo for a partner. 

<img width="1438" height="699" alt="Screenshot 2026-05-19 at 2 21 53 PM" src="https://github.com/user-attachments/assets/84bebaf6-d122-4285-a0fb-f6e5b746451e" />

Partner logo images are uploaded to the existing S3 bucket in a partner-specific folder with a timestamp, eg: ` /partner-{id}/light-logo-26-05-19_14-24-36.png`. The timestamp allows us to upload a new logo while keeping older ones - currently, the most recently uploaded logo is always used. (In a future PR, we could create a component to allow swapping logos for older versions if desired.)

This PR required some refactoring of the upload service to allow uploading partner logo images. The main change is that event-specific hardcoded filepaths were replaced with optional parameters. All existing event upload functionality should work as-is.

## PR Details
### Backend
#### PartnersAuthenticatedController
- Adds new logo upload route to Partners Controller.

#### UploadsService
- New "saveUncompressedImage" method to save images without resizing
- Updates saveToLocal and saveToS3 to take optional folder and filename parameters

### Frontend
#### admin-partner-edit
Main page for updating partners, available from the Admin tab as "Manage Partners". Lists all partners. Future enhancements could include search, associating users, etc.

#### PartnerCard
Main component for editing partners. The bulk of this file is CSS for a "hand-drawn" appearance to buttons and card. Future enhancements could be moving this CSS out into some common CSS and using it for more pages in the app. 