### PR TITLE
Fix Dev Container setup (hopefully)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:0-22
+FROM mcr.microsoft.com/devcontainers/javascript-node:22
 
 RUN apt-get update \
   && apt-get install -y postgresql-client tmux zsh neovim ansible


### PR DESCRIPTION
I tried spinning up a Codespace to check the Dev Container setup after Summer reported it didn't work when she tried it. It bombed out during setup complaining that it couldn't pull the base image for the main container.

Did some searching and found the Github repo's guidance for using this particular container image shows just specifying the Node version after the `:`. I'm not sure what the `0-` part before the Node version originally did, or why it prevents the image from pulling now; I guess Microsoft changed the way the artifact registry worked.

Anyway, this seems to be all that's necessary to get a Codespace to start correctly, so I think this should fix running a dev container locally, too.

Resolves #568

(As an aside, this commit comes from the Codespace I spun up to test this, which received the auto-generated name "psychic bassoon". This is hilarious on its own but also (1) this isn't the first time I've gotten a Codespace name with "bassoon" in it and (2) it's an instrument I play.) 